### PR TITLE
Hhvm compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,10 @@ before_script:
   - composer self-update
   - composer require satooshi/php-coveralls:dev-master --no-update --dev
   - composer install --dev --prefer-source
-  - pyrus install pear/PHP_CodeSniffer
   - phpenv rehash
 
 script:
   - mkdir -p build/logs
 
 after_script:
-  - phpcs --standard=psr2 src/
   - php vendor/bin/coveralls


### PR DESCRIPTION
remove php code sniffer from travis to enable hhvm support
