### PR TITLE
improved filtering methods #12

### DIFF
--- a/examples/filtering.php
+++ b/examples/filtering.php
@@ -9,23 +9,25 @@ $inputCsv = new Reader(new SplFileObject('data/prenoms.csv'));
 $inputCsv->setDelimiter(';');
 $inputCsv->setEncoding("iso-8859-15");
 
-//we filter only the least girl firstname given in 2010
-$filter = function ($row, $index) {
-    return $index > 0                   //we don't take into account the header
-    && isset($row[1], $row[2], $row[3]) //we make sure the data are present
-    && 10 > $row[1]                     //the name is used less than 10 times
-    && 2010 == $row[3]                  //we are looking for the year 2010
-    && 'F' == $row[2];                  //we are only interested in girl firstname
-};
-
-//we order the result according to the number of firstname given
-$sortBy = function ($row1, $row2) {
-    return strcmp($row1[1], $row2[1]);
-};
-
 $res = $inputCsv
-    ->setFilter($filter)
-    ->setSortBy($sortBy)
+    ->addFilter(function ($row, $index) {
+        return $index > 0; //we don't take into account the header
+    })
+    ->addFilter(function ($row) {
+        return isset($row[1], $row[2], $row[3]); //we make sure the data are present
+    })
+    ->addFilter(function ($row) {
+        return 10 > $row[1]; //the name is used less than 10 times
+    })
+    ->addFilter(function ($row) {
+        return 2010 == $row[3]; //we are looking for the year 2010
+    })
+    ->addFilter(function ($row) {
+        return 'F' == $row[2]; //we are only interested in girl firstname
+    })
+    ->addSortBy(function ($row1, $row2) {
+        return strcmp($row1[1], $row2[1]); //we order the result according to the number of firstname given
+    })
     ->setLimit(20) //we just want the first 20 results
     ->fetchAll();
 

--- a/examples/switchmode.php
+++ b/examples/switchmode.php
@@ -47,10 +47,10 @@ $writer->insertAll([
 //we create a Reader object from the Writer object
 $reader = $writer->getReader();
 $names = $reader
-    ->setSortBy(function ($row1, $row2) {
+    ->addSortBy(function ($row1, $row2) {
         return strcmp($row1[0], $row2[0]); //we are sorting the name
     })
-    ->fetchCol(0); //we only return the name column
+    ->fetchCol(); //we only return the name column
 ?>
 <!doctype html>
 <html lang="fr">

--- a/src/Iterator/IteratorFilter.php
+++ b/src/Iterator/IteratorFilter.php
@@ -111,6 +111,18 @@ trait IteratorFilter
     }
 
     /**
+     * Remove all registered callable filter
+     *
+     * @return self
+     */
+    public function clearFilter()
+    {
+        $this->filter = [];
+
+        return $this;
+    }
+
+    /**
     * Filter the Iterator
     *
     * @param \Iterator $iterator
@@ -122,7 +134,7 @@ trait IteratorFilter
         foreach ($this->filter as $callable) {
             $iterator = new CallbackFilterIterator($iterator, $callable);
         }
-        $this->filter = [];
+        $this->clearFilter();
 
         return $iterator;
     }

--- a/src/Iterator/IteratorInterval.php
+++ b/src/Iterator/IteratorInterval.php
@@ -66,7 +66,7 @@ trait IteratorInterval
      *
      * @return self
      */
-    public function setOffset($offset)
+    public function setOffset($offset = 0)
     {
         if (false === filter_var($offset, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]])) {
             throw new InvalidArgumentException('the offset must be a positive integer or 0');
@@ -83,7 +83,7 @@ trait IteratorInterval
      *
      * @return self
      */
-    public function setLimit($limit)
+    public function setLimit($limit = -1)
     {
         if (false === filter_var($limit, FILTER_VALIDATE_INT, ['options' => ['min_range' => -1]])) {
             throw new InvalidArgumentException('the limit must an integer greater or equals to -1');
@@ -106,10 +106,8 @@ trait IteratorInterval
             return $iterator;
         }
         $offset = $this->offset;
-        $limit = -1;
-        if ($this->limit > 0) {
-            $limit = $this->limit;
-        }
+        $limit = $this->limit;
+
         $this->limit = -1;
         $this->offset = 0;
 

--- a/src/Iterator/IteratorSortBy.php
+++ b/src/Iterator/IteratorSortBy.php
@@ -49,18 +49,75 @@ trait IteratorSortBy
      *
      * @var callable
      */
-    private $sortBy;
+    private $sortBy = [];
 
     /**
-     * Set the ArrayObject sort method
+     * Set the Iterator SortBy method
      *
-     * @param callable $sort
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 5.2
+     *
+     * @param callable $callable
      *
      * @return self
      */
-    public function setSortBy(callable $sortBy)
+    public function setSortBy(callable $callable)
     {
-        $this->sortBy = $sortBy;
+        return $this->addSortBy($callable);
+    }
+
+    /**
+     * Set an Iterator sortBy method
+     *
+     * @param callable $filter
+     *
+     * @return self
+     */
+    public function addSortBy(callable $callable)
+    {
+        $this->sortBy[] = $callable;
+
+        return $this;
+    }
+
+    /**
+     * Remove a callable from the collection
+     *
+     * @param callable $filter
+     *
+     * @return self
+     */
+    public function removeSortBy(callable $callable)
+    {
+        $res = array_search($callable, $this->sortBy, true);
+        if (false !== $res) {
+            unset($this->sortBy[$res]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Detect if the callable is already registered
+     *
+     * @param callable $filter
+     *
+     * @return boolean
+     */
+    public function hasSortBy(callable $callable)
+    {
+        return false !== array_search($callable, $this->sortBy, true);
+    }
+
+    /**
+     * Remove all registered callable
+     *
+     * @return self
+     */
+    public function clearSortBy()
+    {
+        $this->sortBy = [];
 
         return $this;
     }
@@ -78,8 +135,19 @@ trait IteratorSortBy
             return $iterator;
         }
         $res = iterator_to_array($iterator, false);
-        uasort($res, $this->sortBy);
-        $this->sortBy  = null;
+
+        uasort($res, function ($rowA, $rowB) {
+            foreach ($this->sortBy as $callable) {
+                $res = $callable($rowA, $rowB);
+                if (0 !== $res) {
+                    break;
+                }
+            }
+
+            return $res;
+        });
+
+        $this->clearSortBy();
 
         return new ArrayIterator($res);
     }

--- a/test/Iterator/IteratorQueryTest.php
+++ b/test/Iterator/IteratorQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Csv\Test\Iterator;
+namespace League\Csv\test\Iterator;
 
 use ArrayIterator;
 use ReflectionClass;
@@ -114,9 +114,16 @@ class IteratorQueryTest extends PHPUnit_Framework_TestCase
     {
         $this->traitQuery->setSortBy('strcmp');
         $iterator = $this->invokeMethod($this->traitQuery, 'execute', [$this->iterator]);
-        $res = iterator_to_array($iterator);
+        $res = iterator_to_array($iterator, false);
+        $this->assertSame(['bar', 'foo', 'jane', 'john'], $res);
 
-        $this->assertSame(['bar', 'foo', 'jane', 'john'], array_values($res));
+        $this->traitQuery->addSortBy('strcmp');
+        $this->traitQuery->addSortBy('strcmp');
+        $this->traitQuery->removeSortBy('strcmp');
+        $this->assertTrue($this->traitQuery->hasSortBy('strcmp'));
+        $iterator = $this->invokeMethod($this->traitQuery, 'execute', [$this->iterator]);
+        $res = iterator_to_array($iterator, false);
+        $this->assertSame(['bar', 'foo', 'jane', 'john'], $res);
     }
 
     public function testExecuteWithCallback()


### PR DESCRIPTION
- `Reader::setLimit` now default to `-1`;
- `Reader::setOffset` now default to `0`;
- Complete Filter API with a `Reader::clearFilter` method to remove all registered filter functions;
- Improve sorting methods to enable easier sorting the API is now similar to the filter API:
  - `Reader::addSortBy` : add a sorting function;
  - `Reader::removeSortBy`: remove a already register sorting function;
  - `Reader::hasSortBy`: check if a function is already registered as a sorting function;
  - `Reader::clearSortBy`: remove all registered function;
  - deprecate `Reader::setSortBy` now a alias of `Reader::addSortBy`;
