### PR TITLE
Iterator query execution order fix

### DIFF
--- a/src/Iterator/IteratorQuery.php
+++ b/src/Iterator/IteratorQuery.php
@@ -68,9 +68,9 @@ trait IteratorQuery
      */
     protected function execute(Iterator $iterator, callable $callable = null)
     {
+        $iterator = $this->applyInterval($iterator);
         $iterator = $this->applyFilter($iterator);
         $iterator = $this->applySortBy($iterator);
-        $iterator = $this->applyInterval($iterator);
         if (! is_null($callable)) {
             $iterator = new MapIterator($iterator, $callable);
         }


### PR DESCRIPTION
Having `IteratorInterval` at the end of the execution causes offset problems when used with an `IteratorFilter`.

For example:

```
$reader->setOffset(200);
$reader->addFilter('someFilterFunction');
foreach ($reader->query() as $index => $row) {
    // $index should be 200 but it returns a value around 600
}
```

Moving `IteratorQuery` in the beginning of execution seems to fix this problem.
