### PR TITLE
Add COUNT_RECURSIVE to fetchRowsCountByDelimiter method

### DIFF
--- a/src/Config/Controls.php
+++ b/src/Config/Controls.php
@@ -139,19 +139,9 @@ trait Controls
             $value = $this->fetchRowsCountByDelimiter($delim, $nb_rows);
         });
 
-        $res = array_filter($res);
         arsort($res, SORT_NUMERIC);
 
-        if (count($res) > 1) {
-            $res_tmp = array_values($res);
-            $umpteen = ($res_tmp[0] / $res_tmp[1]);
-        }
-
-        if (isset($umpteen) && ($umpteen > 2.5)) {
-            return array_search(max($res), $res);
-        } else {
-            return array_keys(array_filter($res));
-        }
+        return array_keys(array_filter($res));
     }
 
     /**


### PR DESCRIPTION
fetchRowsCountByDelimiter method (when we use default $nb_rows = 1 value) always prints 1 for any found delimiters as a result regardless if there are 30 semicolons and only one comma there for example.

So I added the COUNT_RECURSIVE mode in fetchRowsCountByDelimiter method in order we get a relation how often a delimiter is present in the line(s).

Next step would be how the library process the possible valid delimiters based on the amount of occurences we get now!? Do you have any (better) idea?
