### PR TITLE
Use parent methods in MapIterator

### DIFF
--- a/src/Iterator/MapIterator.php
+++ b/src/Iterator/MapIterator.php
@@ -52,6 +52,6 @@ class MapIterator extends IteratorIterator
         $iterator = $this->getInnerIterator();
         $callable = $this->callable;
 
-        return $callable($iterator->current(), $iterator->key(), $iterator);
+        return $callable(parent::current(), parent::key(), $iterator);
     }
 }


### PR DESCRIPTION
The \IteratorIterator accepts any \Traversable object not only Iterators. To support \Traversable objects like PDOStatements as inner iterator you need to access the current item via the iterator methods of the outer iterator.