### PR TITLE
Typo in method name. getConvertionIterator should probably be getConversionIterator

### DIFF
--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -151,7 +151,7 @@ abstract class AbstractCsv implements JsonSerializable, IteratorAggregate
      *
      * @return \Iterator
      */
-    protected function getConvertionIterator()
+    protected function getConversionIterator()
     {
         return $this->getIterator();
     }

--- a/src/Config/Output.php
+++ b/src/Config/Output.php
@@ -51,7 +51,7 @@ trait Output
      *
      * @return \Iterator
      */
-    abstract protected function getConvertionIterator();
+    abstract protected function getConversionIterator();
 
     /**
      * Returns the CSV Iterator
@@ -215,7 +215,7 @@ trait Output
      */
     public function jsonSerialize()
     {
-        return iterator_to_array($this->convertToUtf8($this->getConvertionIterator()), false);
+        return iterator_to_array($this->convertToUtf8($this->getConversionIterator()), false);
     }
 
     /**
@@ -267,7 +267,7 @@ trait Output
     {
         $doc = new DomDocument('1.0', 'UTF-8');
         $root = $doc->createElement($root_name);
-        $iterator = $this->convertToUtf8($this->getConvertionIterator());
+        $iterator = $this->convertToUtf8($this->getConversionIterator());
         foreach ($iterator as $row) {
             $item = $doc->createElement($row_name);
             array_walk($row, function ($value) use (&$item, $doc, $cell_name) {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -63,7 +63,7 @@ class Reader extends AbstractCsv
     /**
      * {@inheritdoc}
      */
-    protected function getConvertionIterator()
+    protected function getConversionIterator()
     {
         $iterator = $this->getIterator();
         $iterator = $this->applyIteratorFilter($iterator);


### PR DESCRIPTION
The docblock comment seems to be correctly spelled.