### PR TITLE
Add associative iterator

### DIFF
--- a/src/Modifier/AssociativeIterator.php
+++ b/src/Modifier/AssociativeIterator.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the League.csv library
+ *
+ * @license http://opensource.org/licenses/MIT
+ * @link https://github.com/thephpleague/csv/
+ * @version 7.0.1
+ * @package League.csv
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace League\Csv\Modifier;
+
+/**
+ *  An iterator to turn numerically indexed arrays into associative arrays.
+ *
+ * @package League.csv
+ */
+class AssociativeIterator extends \IteratorIterator
+{
+    /**
+     * @var array
+     */
+    private $keys;
+
+    /**
+     * @param \Iterator $iterator
+     * @param array $keys
+     */
+    public function __construct(\Iterator $iterator, array $keys)
+    {
+        $this->keys = $keys;
+        parent::__construct($iterator);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        $row = parent::current();
+
+        $keys_count = count($this->keys);
+        if (count($row) !== $keys_count) {
+            $row = array_slice(array_pad($row, $keys_count, null), 0, $keys_count);
+        }
+
+        return array_combine($this->keys, $row);
+    }
+}

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -37,6 +37,11 @@ class Reader extends AbstractCsv
     protected $stream_filter_mode = STREAM_FILTER_READ;
 
     /**
+     * @var array
+     */
+    protected $assoc_keys;
+
+    /**
      * Returns a Filtered Iterator
      *
      * @param callable $callable a callable function to be applied to each Iterator item
@@ -52,6 +57,11 @@ class Reader extends AbstractCsv
         $iterator = $this->applyIteratorFilter($iterator);
         $iterator = $this->applyIteratorSortBy($iterator);
         $iterator = $this->applyIteratorInterval($iterator);
+
+        if (! is_null($this->assoc_keys)) {
+            $iterator = new Modifier\AssociativeIterator($iterator, $this->assoc_keys);
+        }
+
         if (! is_null($callable)) {
             $iterator = new Modifier\MapIterator($iterator, $callable);
         }
@@ -187,6 +197,17 @@ class Reader extends AbstractCsv
         });
 
         return iterator_to_array($iterator, false);
+    }
+
+    public function setAssocKeys($offset_or_keys = 0)
+    {
+        if (false === $offset_or_keys) {
+            $this->assoc_keys = null;
+
+            return;
+        }
+
+        $this->assoc_keys = $this->getAssocKeys($offset_or_keys);
     }
 
     /**


### PR DESCRIPTION
This is just an idea I had while using this lib on large imports. I like the ability to have associative keys, but the build-in functionality forces this to read the entire file failed due to memory limits.

This proposed solution allows us to enable associative keys, yet lazily apply them to each row during iteration.
