### PR TITLE
Empty enclosures should be allowed as per RFC4180

### DIFF
--- a/src/Config/Controls.php
+++ b/src/Config/Controls.php
@@ -159,8 +159,8 @@ trait Controls
      */
     public function setEnclosure($enclosure)
     {
-        if (1 != mb_strlen($enclosure)) {
-            throw new InvalidArgumentException('The enclosure must be a single character');
+        if (1 < mb_strlen($enclosure)) {
+            throw new InvalidArgumentException('The enclosure must be a single character or an empty string');
         }
         $this->enclosure = $enclosure;
 

--- a/test/ControlsTest.php
+++ b/test/ControlsTest.php
@@ -144,7 +144,7 @@ class ControlsTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage The enclosure must be a single character
+     * @expectedExceptionMessage The enclosure must be a single character or an empty string
      */
     public function testEnclosure()
     {


### PR DESCRIPTION
RFC4180 lists enclosures as a SHOULD requirement which allows for them to be omitted. Some legacy apps are not able to handle CSV with enclosed strings so users should be able to not use enclosures.