### PR TITLE
Don't trim $filter_name in sanitizeStreamFilter

### DIFF
--- a/examples/lib/FilterReplace.php
+++ b/examples/lib/FilterReplace.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace lib;
+
+use php_user_filter;
+
+class FilterReplace extends php_user_filter
+{
+    const FILTER_NAME = 'convert.replace.';
+
+    private $search;
+
+    private $replace;
+
+    public function onCreate()
+    {
+        if( strpos( $this->filtername, self::FILTER_NAME ) !== 0 ){
+            return false;
+        }
+
+        $params = substr( $this->filtername, strlen( self::FILTER_NAME ) );
+
+        if( !preg_match( '/([^:]+):([^$]+)$/', $params, $matches ) ){
+            return false;
+        }
+
+        $this->search  = $matches[1];
+        $this->replace = $matches[2];
+
+        return true;
+    }
+
+    public function filter( $in, $out, &$consumed, $closing )
+    {
+        while( $res = stream_bucket_make_writeable( $in ) ){
+
+            $res->data = str_replace( $this->search, $this->replace, $res->data );
+
+            $consumed += $res->datalen;
+
+            /** @noinspection PhpParamsInspection */
+            stream_bucket_append( $out, $res );
+        }
+
+        return PSFS_PASS_ON;
+    }
+}

--- a/src/Modifier/StreamFilter.php
+++ b/src/Modifier/StreamFilter.php
@@ -203,9 +203,7 @@ trait StreamFilter
     protected function sanitizeStreamFilter($filter_name)
     {
         $this->assertStreamable();
-        $filter_name = (string) $filter_name;
-
-        return trim($filter_name);
+        return (string) $filter_name;
     }
 
     /**

--- a/test/newline.csv
+++ b/test/newline.csv
@@ -1,0 +1,2 @@
+1,two,3,"new
+line"


### PR DESCRIPTION
When using `appendStreamFilter` to add a filter to a Writer (or Reader) instance, the name of the filter is sanitised by the `sanitizeStreamFilter` method in StreamFilter.php. This method casts the name to a string, trims and returns it.

Trimming the string causes issues when implementing a filter where it's last argument has a trailing new-line character, for example I am attempting to write a filter that uses `str_replace` which will be used to convert Windows-style line endings (\r\n) to Linux-style (\n), but the Filter's onCreate method receives only the first argument due to trim removing the tailing new line.

**Example code:**

`$writer = Writer::createFromPath( tempnam( sys_get_temp_dir(), 'csv' ) );
stream_filter_register( FilterReplace::FILTER_NAME . "*", FilterReplace::class );
$writer->appendStreamFilter( FilterReplace::FILTER_NAME . "\r\n:\n" );`

Thanks.