### PR TITLE
Don't trim $filter_name argument in sanitizeStreamFilter.

### DIFF
--- a/examples/lib/FilterReplace.php
+++ b/examples/lib/FilterReplace.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace lib;
+
+use php_user_filter;
+
+class FilterReplace extends php_user_filter
+{
+    const FILTER_NAME = 'convert.replace.';
+
+    private $search;
+
+    private $replace;
+
+    public function onCreate()
+    {
+        if( strpos( $this->filtername, self::FILTER_NAME ) !== 0 ){
+            return false;
+        }
+
+        $params = substr( $this->filtername, strlen( self::FILTER_NAME ) );
+
+        if( !preg_match( '/([^:]+):([^$]+)$/', $params, $matches ) ){
+            return false;
+        }
+
+        $this->search  = $matches[1];
+        $this->replace = $matches[2];
+
+        return true;
+    }
+
+    public function filter( $in, $out, &$consumed, $closing )
+    {
+        while( $res = stream_bucket_make_writeable( $in ) ){
+
+            $res->data = str_replace( $this->search, $this->replace, $res->data );
+
+            $consumed += $res->datalen;
+
+            /** @noinspection PhpParamsInspection */
+            stream_bucket_append( $out, $res );
+        }
+
+        return PSFS_PASS_ON;
+    }
+}

--- a/src/Modifier/StreamFilter.php
+++ b/src/Modifier/StreamFilter.php
@@ -203,9 +203,7 @@ trait StreamFilter
     protected function sanitizeStreamFilter($filter_name)
     {
         $this->assertStreamable();
-        $filter_name = (string) $filter_name;
-
-        return trim($filter_name);
+        return (string) $filter_name;
     }
 
     /**

--- a/test/StreamFilterTest.php
+++ b/test/StreamFilterTest.php
@@ -4,6 +4,7 @@ namespace League\Csv\test;
 
 use League\Csv\Reader;
 use League\Csv\Writer;
+use lib\FilterReplace;
 use PHPUnit_Framework_TestCase;
 use SplFileObject;
 use SplTempFileObject;
@@ -113,11 +114,19 @@ class StreamFilterTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($csv->getIterator()->getRealPath());
     }
 
-
     public function testGetFilterPathWithAllStream()
     {
         $filter = 'php://filter/string.toupper/resource='.__DIR__.'/foo.csv';
         $csv = Reader::createFromPath($filter);
         $this->assertFalse($csv->getIterator()->getRealPath());
+    }
+
+    public function testSetStreamFilterWriterNewLine()
+    {
+        stream_filter_register(FilterReplace::FILTER_NAME.'*', '\lib\FilterReplace');
+        $csv = Writer::createFromPath(__DIR__.'/newline.csv');
+        $csv->appendStreamFilter(FilterReplace::FILTER_NAME."\r\n:\n");
+        $this->assertTrue($csv->hasStreamFilter(FilterReplace::FILTER_NAME."\r\n:\n"));
+        $csv->insertOne([1, 'two', 3, "new\r\nline"]);
     }
 }

--- a/test/newline.csv
+++ b/test/newline.csv
@@ -1,0 +1,2 @@
+1,two,3,"new
+line"


### PR DESCRIPTION
This pull request fixes issue #122 - sanitizeStreamFilter is changed to not trim it's $filter_name argument.