### PR TITLE
Bug Fix Spl Flags

### DIFF
--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -94,7 +94,7 @@ abstract class AbstractCsv implements JsonSerializable, IteratorAggregate
      */
     protected function __construct($path, $open_mode = 'r+')
     {
-        $this->flags = SplFileObject::READ_CSV | SplFileObject::DROP_NEW_LINE;
+        $this->flags = SplFileObject::READ_CSV | SplFileObject::READ_AHEAD | SplFileObject::SKIP_EMPTY;
         $this->open_mode = strtolower($open_mode);
         $this->path = $this->normalizePath($path);
         $this->initStreamFilter($this->path);

--- a/src/Config/Output.php
+++ b/src/Config/Output.php
@@ -181,8 +181,8 @@ trait Output
             $bom = $this->output_bom;
         }
         $csv = $this->getIterator();
-        $csv->rewind();
         $csv->setFlags(SplFileObject::READ_CSV);
+        $csv->rewind();
         if (!empty($bom)) {
             $csv->fseek(mb_strlen($input_bom));
         }

--- a/test/ControlsTest.php
+++ b/test/ControlsTest.php
@@ -172,9 +172,10 @@ class ControlsTest extends PHPUnit_Framework_TestCase
     public function testSetFlags()
     {
         $this->assertSame(SplFileObject::READ_CSV, $this->csv->getFlags() & SplFileObject::READ_CSV);
-        $this->assertSame(SplFileObject::DROP_NEW_LINE, $this->csv->getFlags() & SplFileObject::DROP_NEW_LINE);
-        $this->csv->setFlags(SplFileObject::SKIP_EMPTY);
         $this->assertSame(SplFileObject::SKIP_EMPTY, $this->csv->getFlags() & SplFileObject::SKIP_EMPTY);
+        $this->assertSame(SplFileObject::READ_AHEAD, $this->csv->getFlags() & SplFileObject::READ_AHEAD);
+        $this->csv->setFlags(SplFileObject::DROP_NEW_LINE);
+        $this->assertSame(SplFileObject::DROP_NEW_LINE, $this->csv->getFlags() & SplFileObject::DROP_NEW_LINE);
         $this->assertSame(SplFileObject::READ_CSV, $this->csv->getFlags() & SplFileObject::READ_CSV);
 
         $this->csv->setFlags(-3);

--- a/test/CsvTest.php
+++ b/test/CsvTest.php
@@ -79,7 +79,7 @@ class CsvTest extends PHPUnit_Framework_TestCase
      */
     public function testOutputSize()
     {
-        $this->assertSame(60, $this->csv->output('test.csv'));
+        $this->assertSame(60, $this->csv->output(__DIR__.'/data/test.csv'));
     }
 
     /**
@@ -87,7 +87,7 @@ class CsvTest extends PHPUnit_Framework_TestCase
      */
     public function testOutputHeaders()
     {
-        if (! function_exists('xdebug_get_headers')) {
+        if (!function_exists('xdebug_get_headers')) {
             $this->markTestSkipped();
         }
         $this->csv->output('test.csv');


### PR DESCRIPTION
- default flag is now SplFileObject::READ_AHEAD|SplFileObject::SKIP_EMPTY
- AbstractCsv::__toString is also bug fixed