### PR TITLE
Made str_getcsv a removable formatter

### DIFF
--- a/src/Modifier/RowFilter.php
+++ b/src/Modifier/RowFilter.php
@@ -160,7 +160,7 @@ trait RowFilter
      *
      * @return array
      */
-    protected function formatRow(array $row)
+    protected function formatRow($row)
     {
         foreach ($this->formatters as $formatter) {
             $row = call_user_func($formatter, $row);

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -62,6 +62,7 @@ class Writer extends AbstractCsv
     {
         parent::__construct($path, $open_mode);
         static::initFputcsv();
+        $this->addDefaultFormatters();
     }
 
     /**
@@ -110,9 +111,6 @@ class Writer extends AbstractCsv
      */
     public function insertOne($row)
     {
-        if (!is_array($row)) {
-            $row = str_getcsv($row, $this->delimiter, $this->enclosure, $this->escape);
-        }
         $row = $this->formatRow($row);
         $this->validateRow($row);
 
@@ -144,6 +142,24 @@ class Writer extends AbstractCsv
         }
 
         return $parameters;
+    }
+
+    /**
+     * Adds default formatters.
+     *
+     * @return static
+     */
+    private function addDefaultFormatters()
+    {
+        $this->addFormatter(function ($row) {
+            if (is_array($row)) {
+                return $row;
+            }
+
+            return str_getcsv($row, $this->delimiter, $this->enclosure, $this->escape);
+        });
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Like this, users get the option to call `$writer->clearFormatters()` and pass in any type of object and let their custom transformers do the converting to arrays.