### PR TITLE
Improve performance by moving the LimitIterator to the top

### DIFF
--- a/src/Modifier/QueryFilter.php
+++ b/src/Modifier/QueryFilter.php
@@ -158,10 +158,10 @@ trait QueryFilter
         };
         array_unshift($this->iterator_filters, $normalizedCsv);
         $iterator = $this->getIterator();
+        $iterator = $this->applyIteratorInterval($iterator);
         $iterator = $this->applyBomStripping($iterator);
         $iterator = $this->applyIteratorFilter($iterator);
         $iterator = $this->applyIteratorSortBy($iterator);
-        $iterator = $this->applyIteratorInterval($iterator);
 
         return $iterator;
     }


### PR DESCRIPTION
Move the limit iterator to the top because it isn't using `seek` because other iterators aren't implementing the `SeekableInterface`. This is a problem when using an offset.

# Profiling with Blackfire

Profile 1: current implementation
![Profile 1](http://i.imgur.com/SI6UljU.png)

Profile 2: my implementation (moved the `LimitItterator`)
![Profile 2](http://i.imgur.com/jDVUEIJ.png)
