### PR TITLE
Change Output header Content-Type to text/csv

### DIFF
--- a/src/Config/Output.php
+++ b/src/Config/Output.php
@@ -179,7 +179,7 @@ trait Output
     {
         if (null !== $filename) {
             $filename = filter_var($filename, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW);
-            header('Content-Type: application/octet-stream');
+            header('Content-Type: text/csv');
             header('Content-Transfer-Encoding: binary');
             header("Content-Disposition: attachment; filename=\"$filename\"");
         }

--- a/test/CsvTest.php
+++ b/test/CsvTest.php
@@ -94,7 +94,10 @@ class CsvTest extends AbstractTestCase
         }
         $this->csv->output('test.csv');
         $headers = \xdebug_get_headers();
-        $this->assertSame($headers[0], 'Content-Type: application/octet-stream');
+
+        // Due to the variety of ways the xdebug expresses Content-Type of text files,
+        // we cannot count on complete string matching.
+        $this->assertContains('content-type: text/csv', strtolower($headers[0]));
         $this->assertSame($headers[1], 'Content-Transfer-Encoding: binary');
         $this->assertSame($headers[2], 'Content-Disposition: attachment; filename="test.csv"');
     }


### PR DESCRIPTION
## Introduction

Currently, `Output#output` expects to render a CSV file, but does not set the correct Content-Type header.

## Proposal 

### Describe the new/upated/fixed feature

Per [RFC 7111](https://tools.ietf.org/html/rfc7111), the content type is available `text/csv`. 

Further, [HTTP 1.1 7.2.1](https://www.w3.org/Protocols/rfc2616/rfc2616-sec7.html#sec7) states `octet-stream` should only be used when the content-type is uknown. 
> If and only if the media type is not given by a Content-Type field, the recipient MAY attempt to guess the media type via inspection of its content and/or the name extension(s) of the URI used to identify the resource. If the media type remains unknown, the recipient SHOULD treat it as type "application/octet-stream". 

`Output#output` sets Content-Type as `text/csv`

### Backward Incompatible Changes

None

### Targeted release version

8.1.1

### PR Impact

None observed

## Open issues

None
