### PR TITLE
Update link to CONTRIB doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ composer test
 Contributing
 -------
 
-Contributions are welcome and will be fully credited. Please see [CONTRIBUTING](CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.
+Contributions are welcome and will be fully credited. Please see [CONTRIBUTING](.github/CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.
 
 Security
 -------


### PR DESCRIPTION
## Introduction

Invalid link in README.md

## Proposal 

### Describe the new/upated/fixed feature

Correct link to .github/CONTRIBUTING.md

### Backward Incompatible Changes

None

### Targeted release version

8.1.1

### PR Impact

None

## Open issues

None

