### PR TITLE
Adding RFC4180 Field stream filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All Notable changes to `Csv` will be documented in this file
 - Improved CSV document flush mechanism on insertion
     - `League\Csv\Writer::setFlushThreshold`
     - `League\Csv\Writer::getFlushThreshold`
+- Improve RFC4180 compliance
+    - `League\Csv\RFC4180Field` to format field according to RFC4180 rules
 
 ### Deprecated
 

--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -10,7 +10,6 @@ version:
             BOM Sequences: '/9.0/connections/bom/'
             Stream Filters: '/9.0/connections/filters/'
             Document output: '/9.0/connections/output/'
-            Interoperability: '/9.0/connections/interoperability/'
             Exceptions: '/9.0/connections/exceptions/'
         Inserting Records:
             Writer Connection: '/9.0/writer/'
@@ -25,6 +24,8 @@ version:
             Json Converter: '/9.0/converter/json/'
             XML Converter: '/9.0/converter/xml/'
             HTML Converter: '/9.0/converter/html/'
+        Interoperability:
+            Overview : '/9.0/interoperability/'
     '8.0':
         Getting Started:
             Overview: '/8.0/'

--- a/src/RFC4180Field.php
+++ b/src/RFC4180Field.php
@@ -1,0 +1,100 @@
+<?php
+/**
+* This file is part of the League.csv library
+*
+* @license http://opensource.org/licenses/MIT
+* @link https://github.com/thephpleague/csv/
+* @version 9.0.0
+* @package League.csv
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+declare(strict_types=1);
+
+namespace League\Csv;
+
+use php_user_filter;
+use Throwable;
+
+/**
+ *  A stream filter to conform the written CSV field to RFC4180
+ *  This stream filter should be attach to a League\Csv\Writer object
+ *
+ * @package League.csv
+ * @since   9.0.0
+ * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ */
+class RFC4180Field extends php_user_filter
+{
+    use ValidatorTrait;
+
+    const STREAM_FILTERNAME = 'rfc4180.league.csv';
+
+    /**
+     * The value being search for
+     *
+     * @var string
+     */
+    protected $search;
+
+    /**
+     * The replacement value that replace found $search values
+     *
+     * @var string
+     */
+    protected $replace;
+
+    /**
+     * Static method to add the stream filter to a Writer object
+     *
+     * @param AbstractCsv $csv
+     */
+    public static function addTo(AbstractCsv $csv)
+    {
+        if (!in_array(self::STREAM_FILTERNAME, stream_get_filters())) {
+            stream_filter_register(self::STREAM_FILTERNAME, __CLASS__);
+        }
+
+        $csv->addStreamFilter(self::STREAM_FILTERNAME, [
+            'enclosure' => $csv->getEnclosure(),
+            'escape' => $csv->getEscape(),
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onCreate()
+    {
+        if (!isset($this->params['enclosure'], $this->params['escape'])) {
+            return false;
+        }
+
+        try {
+            $enclosure = $this->filterControl($this->params['enclosure'], 'enclosure', __METHOD__);
+            $escape = $this->filterControl($this->params['escape'], 'escape', __METHOD__);
+
+            $this->search = $escape.$enclosure;
+            $this->replace = $escape.$enclosure.$enclosure;
+
+            return true;
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function filter($in, $out, &$consumed, $closing)
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $bucket->data = str_replace($this->search, $this->replace, $bucket->data);
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+
+        return PSFS_PASS_ON;
+    }
+}

--- a/tests/RFC4180FieldTest.php
+++ b/tests/RFC4180FieldTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace LeagueTest\Csv;
+
+use League\Csv\RFC4180Field;
+use League\Csv\Writer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group writer
+ * @coversDefaultClass League\Csv\RFC4180Field
+ */
+class RFC4180FieldTest extends TestCase
+{
+    /**
+     * Example taken from PHP bug #43225
+     *
+     * @see https://bugs.php.net/bug.php?id=43225
+     *
+     * @covers ::addTo
+     * @covers ::onCreate
+     * @covers ::filter
+     */
+    public function testStreamFilter()
+    {
+        $expected = '"a\""",bbb'."\r\n";
+        $csv = Writer::createFromStream(fopen('php://temp', 'r+'));
+
+        RFC4180Field::addTo($csv);
+
+        $res = stream_get_filters();
+        $this->assertContains(RFC4180Field::STREAM_FILTERNAME, $res);
+        $csv->setNewline("\r\n");
+        $csv->insertOne(['a\\"', 'bbb']);
+        $this->assertSame($expected, (string) $csv);
+    }
+
+    /**
+     * @covers ::onCreate
+     */
+    public function testOnCreateFailedWithoutParams()
+    {
+        $filter = new RFC4180Field();
+        $this->assertFalse($filter->onCreate());
+    }
+
+    /**
+     * @covers ::onCreate
+     */
+    public function testOnCreateFailedWithWrongParams()
+    {
+        $filter = new RFC4180Field();
+        $filter->params = [
+            'enclosure' => '"',
+            'escape' => 'foo',
+        ];
+        $this->assertFalse($filter->onCreate());
+    }
+}


### PR DESCRIPTION
- `RFC4180Field` stream filter enables RFC4180 compliance by bugfixing `fputcsv` behaviour on field content.
- simplify stream filter by adding a static `addTo` method to register and add the stream on the CSV object in one call

- documentation is update accordingly
