### PR TITLE
Allow remote streams in Reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All Notable changes to `Csv` will be documented in this file
     - `League\Csv\Writer::getFlushThreshold`
 - Improve RFC4180 compliance
     - `League\Csv\RFC4180FieldFormatter` to format field according to RFC4180 rules
+- Add connection to non-seekable resources
+    - `League\Csv\Reader::createFromUrl` to connect non-seekable resources like HTTP.
 
 ### Deprecated
 

--- a/docs/9.0/connections/instantiation.md
+++ b/docs/9.0/connections/instantiation.md
@@ -97,3 +97,35 @@ $writer = Writer::createFromFileObject(new SplTempFileObject());
 ~~~
 
 <p class="message-warning"> The <code>SplFileObject</code> <strong>MUST</strong> be seekable otherwise a <code>RuntimeException</code> exception may be thrown.</p>
+
+## Loading from a Url (Only Reader)
+
+~~~php
+<?php
+
+public static Reader::createFromUrl(
+	string $url,
+	string $open_mode = 'r',
+	resource $context = null
+): self
+~~~
+
+Creates a new object from an `Url`.
+
+~~~php
+<?php
+
+use League\Csv\Reader;
+
+$context = stream_context_create([
+	'http' => [
+		'protocol_version' => 1.1,
+		'header'           => [
+			'Connection: close',
+		],
+	],
+]);
+$reader = Reader::createFromFileObject('http://domain/path/to/file.csv', 'r', $context);
+~~~
+
+<p class="message-warning"> The <code>Url</code> <strong>MAY</strong> be non-seekable because the stream is copied to another one seekable, so you can use HTTP.</p>

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -61,6 +61,21 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
     protected $stream_filter_mode = STREAM_FILTER_READ;
 
     /**
+     * Return a new instance from a file path
+     *
+     * @param string        $url       file url
+     * @param string        $open_mode the file open mode flag
+     * @param resource|null $context   the resource context
+     *
+     * @return static
+     */
+    public static function createFromUrl(string $url, string $open_mode = 'r+', $context = null): self
+    {
+        $stream = Stream::createFromUrl($url, $open_mode, $context);
+        return new static(new Stream($stream));
+    }
+
+    /**
      * Returns the record offset used as header
      *
      * If no CSV record is used this method MUST return null

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -120,6 +120,32 @@ class Stream implements SeekableIterator
     }
 
     /**
+     * Create a resource.
+     *
+     * @param string $url       file url
+     * @param string $open_mode the file open mode flag
+     * @param null   $context   the resource context
+     *
+     * @throws Exception if the stream resource can not be created
+     *
+     * @return resource
+     */
+    private static function createResource(string $url, string $open_mode, $context)
+    {
+        $args = [$url, $open_mode];
+        if (null !== $context) {
+            $args[] = false;
+            $args[] = $context;
+        }
+
+        if (!$resource = @fopen(...$args)) {
+            throw new Exception(error_get_last()['message']);
+        }
+
+        return $resource;
+    }
+
+    /**
      * @inheritdoc
      */
     public function __destruct()
@@ -151,9 +177,9 @@ class Stream implements SeekableIterator
     public function __debugInfo()
     {
         return stream_get_meta_data($this->stream) + [
-            'delimiter' => $this->delimiter,
-            'enclosure' => $this->enclosure,
-            'escape' => $this->escape,
+            'delimiter'      => $this->delimiter,
+            'enclosure'      => $this->enclosure,
+            'escape'         => $this->escape,
             'stream_filters' => array_keys($this->filters),
         ];
     }
@@ -171,17 +197,37 @@ class Stream implements SeekableIterator
      */
     public static function createFromPath(string $path, string $open_mode = 'r', $context = null): self
     {
-        $args = [$path, $open_mode];
-        if (null !== $context) {
-            $args[] = false;
-            $args[] = $context;
-        }
-
-        if (!$resource = @fopen(...$args)) {
-            throw new Exception(error_get_last()['message']);
-        }
+        $resource = self::createResource($path, $open_mode, $context);
 
         $instance = new static($resource);
+        $instance->should_close_stream = true;
+
+        return $instance;
+    }
+
+    /**
+     * Return a new instance from a file url.
+     *
+     * @param string $url       file url
+     * @param string $open_mode the file open mode flag
+     * @param null   $context   the resource context
+     *
+     * @see http://php.net/manual/es/wrappers.php
+     *
+     * @throws Exception if the stream resource can not be created
+     *
+     * @return static
+     */
+    public static function createFromUrl(string $url, string $open_mode = 'r', $context = null): self
+    {
+        $resourceOrigin = self::createResource($url, $open_mode, $context);
+        rewind($resourceOrigin);
+
+        $resourceDestination = fopen('php://temp', 'r+');
+        stream_copy_to_stream($resourceOrigin, $resourceDestination);
+        rewind($resourceDestination);
+
+        $instance = new static($resourceDestination);
         $instance->should_close_stream = true;
 
         return $instance;
@@ -221,6 +267,7 @@ class Stream implements SeekableIterator
         $res = @stream_filter_append($this->stream, $filtername, $read_write, $params);
         if (is_resource($res)) {
             $this->filters[$filtername][] = $res;
+
             return;
         }
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -87,6 +87,32 @@ class StreamTest extends TestCase
     }
 
     /**
+     * @covers ::createFromPath
+     * @covers ::current
+     */
+    public function testCreateStreamFromUrlWithContext()
+    {
+        $fp = fopen('php://temp', 'r+');
+        $expected = [
+            ['john', 'doe', 'john.doe@example.com'],
+            ['john', 'doe', 'john.doe@example.com'],
+        ];
+
+        foreach ($expected as $row) {
+            fputcsv($fp, $row);
+        }
+
+        $stream = Stream::createFromUrl(
+            StreamWrapper::PROTOCOL.'://stream',
+            'r+',
+            stream_context_create([StreamWrapper::PROTOCOL => ['stream' => $fp]])
+        );
+        $stream->setFlags(SplFileObject::READ_AHEAD);
+        $stream->rewind();
+        $this->assertInternalType('array', $stream->current());
+    }
+
+    /**
      * @covers ::fputcsv
      * @dataProvider fputcsvProvider
      *

--- a/tests/StreamWrapper.php
+++ b/tests/StreamWrapper.php
@@ -90,20 +90,6 @@ final class StreamWrapper
      */
     public function stream_stat()
     {
-        return [
-            'dev'     => 0,
-            'ino'     => 0,
-            'mode'    => 33206,
-            'nlink'   => 0,
-            'uid'     => 0,
-            'gid'     => 0,
-            'rdev'    => 0,
-            'size'    => 0,
-            'atime'   => 0,
-            'mtime'   => 0,
-            'ctime'   => 0,
-            'blksize' => 0,
-            'blocks'  => 0,
-        ];
+        return fstat($this->stream);
     }
 }


### PR DESCRIPTION
## Introduction

This PR will allow the Reader to use non-seekable streams like remote streams (HTTP or FTP).

## Proposal 

### Describe the new/upated/fixed feature

To allow the reader to use that new streams, the library should add a new method to that streams type. The stream will be transformed inside the library in a seekable stream. To improve the performance, it will be create in memory is it is small (default 2MB) or in a temporary file if it is bigger. 

### Backward Incompatible Changes

It is 100% backward compatible.

### Targeted release version

9.0

### PR Impact

This PR will modify the Reader API and will allow the use of remote streams out of the box.

## Open issues


