### PR TITLE
Enable empty enclosure, support imports into old systems

### DIFF
--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -354,9 +354,7 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @param string $enclosure
      *
-     * @throws Exception If the Csv control character is not one character only.
-     *
-     * @return static
+     * @return AbstractCsv
      */
     public function setEnclosure(string $enclosure): self
     {

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -364,14 +364,10 @@ abstract class AbstractCsv implements ByteSequence
             return $this;
         }
 
-        if (1 === strlen($enclosure)) {
-            $this->enclosure = $enclosure;
-            $this->resetProperties();
+        $this->enclosure = $enclosure;
+        $this->resetProperties();
 
-            return $this;
-        }
-
-        throw new Exception(sprintf('%s() expects enclosure to be a single character %s given', __METHOD__, $enclosure));
+        return $this;
     }
 
     /**


### PR DESCRIPTION
## Introduction

Enable empty enclosure

Set enclosure now accept an even empty string. Most of the old systems, for which we might create CSVs, do not accept CSV import with quote enclosure or any other, that's why the library should be flexible

## Proposal 

setEnclosure('') - removed the exception if the enclosure is less then 1 char

### Backward Incompatible Changes

No need

### Targeted release version

9.0.1

