### PR TITLE
Feature/add chunk to 8x (WIP)

### DIFF
--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -292,7 +292,7 @@ abstract class AbstractCsv implements JsonSerializable, IteratorAggregate
             yield $chunk;
         }
 
-        while (!$document->eof()) {
+        while ($document->valid()) {
             yield $document->fread($length);
         }
     }

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -292,7 +292,7 @@ abstract class AbstractCsv implements JsonSerializable, IteratorAggregate
             yield $chunk;
         }
 
-        while ($document->valid()) {
+        while (!$document->eof()) {
             yield $document->fread($length);
         }
     }

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -270,4 +270,30 @@ abstract class AbstractCsv implements JsonSerializable, IteratorAggregate
 
         return new SplFileObject($this->getStreamFilterPath(), $this->open_mode);
     }
+
+    /**
+     * Returns the CSV document as a Generator of string chunk
+     *
+     * @param int $length number of bytes read
+     *
+     * @return Generator
+     */
+    public function chunk($length)
+    {
+        if ($length < 1) {
+            throw new InvalidArgumentException(sprintf('%s() expects the length to be a positive integer %d given', __METHOD__, $length));
+        }
+
+        $document = $this->getIterator();
+        $input_bom = $this->getInputBOM();
+        $document->rewind();
+        $document->fseek(strlen($input_bom));
+        foreach (str_split($this->output_bom.$document->fread($length), $length) as $chunk) {
+            yield $chunk;
+        }
+
+        while ($document->valid()) {
+            yield $document->fread($length);
+        }
+    }
 }

--- a/test/CsvTest.php
+++ b/test/CsvTest.php
@@ -108,4 +108,25 @@ class CsvTest extends PHPUnit_Framework_TestCase
         $expected = "john,doe,john.doe@example.com\njane,doe,jane.doe@example.com\n";
         $this->assertSame($expected, $this->csv->__toString());
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testChunkTriggersException()
+    {
+        $chunk = $this->csv->chunk(0);
+        iterator_to_array($chunk);
+    }
+
+    public function testChunk()
+    {
+        $raw_csv = Reader::BOM_UTF8."john,doe,john.doe@example.com\njane,doe,jane.doe@example.com\n";
+        $csv = Reader::createFromString($raw_csv)->setOutputBOM(Reader::BOM_UTF32_BE);
+        $expected = Reader::BOM_UTF32_BE."john,doe,john.doe@example.com\njane,doe,jane.doe@example.com\n";
+        $res = '';
+        foreach ($csv->chunk(8192) as $chunk) {
+            $res .= $chunk;
+        }
+        $this->assertSame($expected, $res);
+    }
 }


### PR DESCRIPTION
**WORK IN PROGRESS, DO NOT MERGE**

I would be interested in any immediate feedback on my proposed changes. However, I have not tested this code beyond running the unit tests. Please refrain from merging until I can confirm that this actually works. 😝 

## Introduction

This pull request backports the method `AbstractCsv::chunk` (see https://github.com/thephpleague/csv/blob/master/src/AbstractCsv.php#L277) to allow output as a streaming response in a memory-efficient way for very large CSVs.

## Proposal 

### Describe the new/upated/fixed feature

See above.

### Backward Incompatible Changes

This change is strictly additive–no incompatibility should arise.

### Targeted release version

I'm not sure how you manage releases. Please provide guidance.

### PR Impact

Should add the method `AbstractCsv::chunk` to allow memory-efficient output of large CSVs.
