### PR TITLE
Fixing small typo

### DIFF
--- a/docs/9.0/connections/output.md
+++ b/docs/9.0/connections/output.md
@@ -155,7 +155,7 @@ $csv->insertAll($stmt);
 //see Symfony documentation for more information
 $flush_threshold = 1000; //the flush value should depend on your CSV size.
 $content_callback = function () use ($csv, $flush_threshold) {
-    foreach ($reader->chunk(1024) as $offset => $chunk) {
+    foreach ($csv->chunk(1024) as $offset => $chunk) {
         echo $chunk;
         if ($offset % $flush_threshold === 0) {
             flush();


### PR DESCRIPTION
This PR makes a small fix to a typo in the documentation for outputting CSVs.