### PR TITLE
Fix grammar & typo in 'Stream support detection' v9 Upgrading doc

### DIFF
--- a/docs/upgrading/9.0.md
+++ b/docs/upgrading/9.0.md
@@ -394,7 +394,7 @@ foreach ($records->fetchColumn(0) as $value) {
 
 ### Stream support detection
 
-To detect if a PHP stream filters are supported you neet to call `AbstractCsv::supportsStreamFilter`
+To detect if PHP stream filters are supported you need to call `AbstractCsv::supportsStreamFilter`
 
 Before:
 


### PR DESCRIPTION
Reading the Upgrading docs I noticed the misspelled `need`, and after looking twice also that the `a` doesn't fit.