### PR TITLE
Fix possible null reference in Stream __debugInfo

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -147,7 +147,7 @@ class Stream implements SeekableIterator
      */
     public function __debugInfo()
     {
-        return stream_get_meta_data($this->stream) + [
+        return $this->stream ? stream_get_meta_data($this->stream) : [] + [
             'delimiter' => $this->delimiter,
             'enclosure' => $this->enclosure,
             'escape' => $this->escape,


### PR DESCRIPTION
When error occurs in constructor, before `stream` variable is defined, the error message is cryptic as __debugInfo() fails.
