### PR TITLE
Override the createFromPath static method for a simple open mode on Reader

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -62,6 +62,14 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
     protected $stream_filter_mode = STREAM_FILTER_READ;
 
     /**
+     * @inheritdoc
+     */
+    public static function createFromPath(string $path, string $open_mode = 'r', $context = null): AbstractCsv
+    {
+        return new static(Stream::createFromPath($path, $open_mode, $context));
+    }
+
+    /**
      * Returns the header offset
      *
      * If no CSV header offset is set this method MUST return null

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -349,4 +349,13 @@ class ReaderTest extends TestCase
             json_encode($reader)
         );
     }
+
+    /**
+     * @covers ::createFromPath
+     */
+    public function testCreateFromPath()
+    {
+        $csv = Reader::createFromPath(__DIR__.'/data/foo_readonly.csv');
+        $this->assertCount(1, $csv);
+    }
 }

--- a/tests/data/foo_readonly.csv
+++ b/tests/data/foo_readonly.csv
@@ -1,0 +1,1 @@
+john,doe,john.doe@example.com


### PR DESCRIPTION
## Introduction

I actually got bit by the readonly issue that is described in #258 And figured I'd give a shot at how to fix the issue.

## Proposal 

I introduce a new static method in reader where the default open mode is 'r'. I also added a test to ensure this works by adding a readonly csv file.

### Describe the new/upated/fixed feature

I override the static function ```createFromPath``` provided by AbstractCsv to set the default open mode.
### Backward Incompatible Changes

There shouldn't be a BC issue.

### Targeted release version

Could be 9.0, 10.0, up to you. This is my first time writing a PR for a PHP library like this so its very much a learning experience for me 😄 

### PR Impact

I don't think there should be a PR impact.

## Open issues

#258 
