### PR TITLE
Explicitly call out 'r' permission in docs

### DIFF
--- a/docs/7.0/basic-usage.md
+++ b/docs/7.0/basic-usage.md
@@ -12,7 +12,7 @@ Once your CSV object is [instantiated](/7.0/instantiation) and [configured](/7.0
 ~~~php
 <?php
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 foreach ($reader as $index => $row) {
     //do something meaningful here with $row !!
     //$row is an array where each item represent a CSV data cell

--- a/docs/7.0/bom.md
+++ b/docs/7.0/bom.md
@@ -24,7 +24,7 @@ This method will detect and return the `BOM` character used in your CSV if any.
 ~~~php
 <?php
 
-$reader = new Reader::createFromPath('path/to/your/file.csv');
+$reader = new Reader::createFromPath('/path/to/your/file.csv', 'r');
 $res = $reader->getInputBOM(); //$res equals null if no BOM is found
 
 $reader = new Reader::createFromPat('path/to/your/msexcel.csv');
@@ -57,7 +57,7 @@ This method will tell you at any given time what `BOM` character will be prepend
 ~~~php
 <?php
 
-$reader = new Reader::createFromPath('path/to/your/file.csv');
+$reader = new Reader::createFromPath('/path/to/your/file.csv', 'r');
 $reader->getOutputBOM(); //$res equals null;
 $reader->setOutputBOM(Reader::BOM_UTF16LE);
 $res = $reader->getOutputBOM(); //$res equals "\xFF\xFE";
@@ -84,7 +84,7 @@ use League\Csv\Reader;
 
 require '../vendor/autoload.php';
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setOutputBOM(Reader::BOM_UTF8);
 //BOM detected and adjusted for the output
 echo $reader->__toString();

--- a/docs/7.0/examples.md
+++ b/docs/7.0/examples.md
@@ -14,7 +14,7 @@ A simple example to show you how to parse a CSV document.
 <?php
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 //get the first row, usually the CSV header
 $headers = $csv->fetchOne();
@@ -74,7 +74,7 @@ $sth = $dbh->prepare(
 	"INSERT INTO users (firstname, lastname, email) VALUES (:firstname, :lastname, :email)"
 );
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $csv->setOffset(1); //because we don't want to insert the header
 $nbInsert = $csv->each(function ($row) use (&$sth) {
 	//Do not forget to validate your data before inserting it in your database

--- a/docs/7.0/filtering.md
+++ b/docs/7.0/filtering.md
@@ -28,7 +28,7 @@ To be sure that the Stream Filter API is available it is recommend to use the me
 use League\Csv\Reader;
 use League\Csv\Writer;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->isActiveStreamFilter(); //return true
 
 $writer = Writer::createFromFileObject(new SplTempFileObject());
@@ -55,7 +55,7 @@ By default:
 
 use \League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 if ($reader->isActiveStreamFilter()) {
 	$current_mode = $reader->getStreamFilterMode(); //returns STREAM_FILTER_READ
 	$reader->setStreamFilterMode(STREAM_FILTER_WRITE);
@@ -94,7 +94,7 @@ use League\Csv\Reader;
 stream_filter_register('convert.utf8decode', 'MyLib\Transcode');
 // 'MyLib\Transcode' is a class that extends PHP's php_user_filter class
 
-$reader = Reader::createFromPath('/path/to/my/chinese.csv');
+$reader = Reader::createFromPath('/path/to/my/chinese.csv', 'r');
 if ($reader->isActiveStreamFilter()) {
 	$reader->appendStreamFilter('string.toupper');
 	$reader->appendStreamFilter('string.rot13');
@@ -114,7 +114,7 @@ foreach ($reader as $row) {
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/chinese.csv');
+$reader = Reader::createFromPath('/path/to/my/chinese.csv', 'r');
 $filter = urlencode('convert.iconv.UTF-8/ASCII//TRANSLIT);
 $reader->appendStreamFilter($filter);
 var_dump($reader->fetchAll());

--- a/docs/7.0/index.md
+++ b/docs/7.0/index.md
@@ -18,6 +18,13 @@ layout: default
 PHP. The goal of the library is to be as powerful while remaining lightweight,
 by utilizing PHP native classes whenever possible.
 
+## Notes
+
+By default, the mode for a `Reader::createFromPath()` is
+`'r+'` which looks for write permissions on the file and throws an Exception if
+the file cannot be opened with the permission set. For sake of clarity, it is
+strongly suggested to set `'r'` mode on the file to ensure it can be opened.
+
 ## Examples
 
 ### Parsing a document
@@ -29,7 +36,7 @@ A simple example to show you how to parse a CSV document.
 <?php
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 //get the first row, usually the CSV header
 $headers = $csv->fetchOne();
@@ -89,7 +96,7 @@ $sth = $dbh->prepare(
 	"INSERT INTO users (firstname, lastname, email) VALUES (:firstname, :lastname, :email)"
 );
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $csv->setOffset(1); //because we don't want to insert the header
 $nbInsert = $csv->each(function ($row) use (&$sth) {
 	//Do not forget to validate your data before inserting it in your database

--- a/docs/7.0/instantiation.md
+++ b/docs/7.0/instantiation.md
@@ -50,7 +50,7 @@ The resulting string and `$open_mode` parameters are used to lazy load internall
 use League\Csv\Reader;
 use League\Csv\Writer;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 //the $reader object will use the 'r+' open mode as no `open_mode` parameter was supplied.
 $writer = Writer::createFromPath(new SplFileObject('/path/to/your/csv/file.csv', 'a+'), 'w');
 //the $writer object open mode will be 'w'!!

--- a/docs/7.0/properties.md
+++ b/docs/7.0/properties.md
@@ -78,7 +78,7 @@ The method takes two arguments:
 ~~~php
 <?php
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 $reader->setEnclosure('"');
 $reader->setEscape('\\');
@@ -114,7 +114,7 @@ The method takes two arguments:
 ~~~php
 <?php
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 $reader->setEnclosure('"');
 $reader->setEscape('\\');

--- a/docs/7.0/reading.md
+++ b/docs/7.0/reading.md
@@ -7,6 +7,13 @@ title: Extracting data from a CSV
 
 To extract data from a CSV document use `League\Csv\Reader` methods.
 
+## Notes
+
+By default, the mode for a `Reader::createFromPath()` is
+`'r+'` which looks for write permissions on the file and throws an Exception if
+the file cannot be opened with the permission set. For sake of clarity, it is
+strongly suggested to set `'r'` mode on the file to ensure it can be opened.
+
 ## Fetching CSV data
 
 ### query(callable $callable = null)

--- a/docs/8.0/basic-usage.md
+++ b/docs/8.0/basic-usage.md
@@ -28,7 +28,7 @@ You can iterate over your CSV object to extract each CSV row using the `foreach`
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 foreach ($reader as $index => $row) {
     //do something meaningful here with $row !!
     //$row is an array where each item represent a CSV data cell
@@ -59,7 +59,7 @@ Use the `echo` construct on the instantiated object or use the `__toString` meth
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 echo $reader;
 // or
 echo $reader->__toString();
@@ -89,7 +89,7 @@ use League\Csv\Reader;
 header('Content-Type: text/csv; charset=UTF-8');
 header('Content-Disposition: attachment; filename="name-for-your-file.csv"');
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->output();
 die;
 ~~~
@@ -101,7 +101,7 @@ die;
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->output("name-for-your-file.csv");
 die;
 ~~~
@@ -116,7 +116,7 @@ In some cases you can also use a Streaming Response for larger files.
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 return new Response((string) $reader, 200, [
 	'Content-Type' => 'text/csv; charset=UTF-8',
 	'Content-Disposition' => 'attachment; filename="name-for-your-file.csv"',

--- a/docs/8.0/bom.md
+++ b/docs/8.0/bom.md
@@ -33,10 +33,10 @@ public AbstractCsv::getInputBOM(void): string
 
 use League\Csv\Reader;
 
-$reader = new Reader::createFromPath('path/to/your/file.csv');
+$reader = new Reader::createFromPath('/path/to/your/file.csv', 'r');
 $res = $reader->getInputBOM(); //$res equals '' if no BOM is found
 
-$reader = new Reader::createFromPath('path/to/your/msexcel.csv');
+$reader = new Reader::createFromPath('/path/to/your/msexcel.csv', 'r');
 if (Reader::BOM_UTF16_LE == $reader->getInputBOM()) {
 	//the CSV file is encoded using UTF-16 LE
 }
@@ -80,7 +80,7 @@ public AbstractCsv::getOutputBOM(void): string
 
 use League\Csv\Reader;
 
-$reader = new Reader::createFromPath('path/to/your/file.csv');
+$reader = new Reader::createFromPath('/path/to/your/file.csv', 'r');
 $reader->getOutputBOM(); //$res equals null;
 $reader->setOutputBOM(Reader::BOM_UTF16_LE);
 $res = $reader->getOutputBOM(); //$res equals "\xFF\xFE";
@@ -105,7 +105,7 @@ On Windows, MS Excel, expects an UTF-8 encoded CSV with its corresponding `BOM` 
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setOutputBOM(Reader::BOM_UTF8);
 //BOM detected and adjusted for the output
 echo $reader->__toString();

--- a/docs/8.0/converting.md
+++ b/docs/8.0/converting.md
@@ -47,7 +47,7 @@ This method accepts 3 optionals arguments to help you customize the XML tree:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $dom = $reader->toXML('data', 'line', 'item');
 ~~~
 
@@ -69,7 +69,7 @@ rendering. By defaut the classname given to the table is `table-csv-data`.
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 echo $reader->toHTML('table table-bordered table-hover');
 ~~~
 

--- a/docs/8.0/examples.md
+++ b/docs/8.0/examples.md
@@ -15,7 +15,7 @@ A simple example to show you how to parse a CSV document.
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 //get the first row, usually the CSV header
 $headers = $csv->fetchOne();
@@ -75,7 +75,7 @@ $sth = $dbh->prepare(
 	"INSERT INTO users (firstname, lastname, email) VALUES (:firstname, :lastname, :email)"
 );
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $csv->setOffset(1); //because we don't want to insert the header
 $nbInsert = $csv->each(function ($row) use (&$sth) {
 	//Do not forget to validate your data before inserting it in your database
@@ -97,7 +97,7 @@ The below example tries to determine the encoding and convert to `UTF-8` using t
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 $input_bom = $reader->getInputBOM();
 

--- a/docs/8.0/filtering.md
+++ b/docs/8.0/filtering.md
@@ -36,7 +36,7 @@ public AbstractCsv::isActiveStreamFilter(void): bool
 use League\Csv\Reader;
 use League\Csv\Writer;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->isActiveStreamFilter(); //return true
 
 $writer = Writer::createFromFileObject(new SplTempFileObject());
@@ -72,7 +72,7 @@ By default:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 if ($reader->isActiveStreamFilter()) {
 	$current_mode = $reader->getStreamFilterMode(); //returns STREAM_FILTER_READ
 	$reader->setStreamFilterMode(STREAM_FILTER_WRITE);
@@ -121,7 +121,7 @@ use League\Csv\Reader;
 stream_filter_register('convert.utf8decode', 'MyLib\Transcode');
 // 'MyLib\Transcode' is a class that extends PHP's php_user_filter class
 
-$reader = Reader::createFromPath('/path/to/my/chinese.csv');
+$reader = Reader::createFromPath('/path/to/my/chinese.csv', 'r');
 if ($reader->isActiveStreamFilter()) {
 	$reader->appendStreamFilter('string.toupper');
 	$reader->appendStreamFilter('string.rot13');
@@ -141,7 +141,7 @@ foreach ($reader as $row) {
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/chinese.csv');
+$reader = Reader::createFromPath('/path/to/my/chinese.csv', 'r');
 $reader->appendStreamFilter('convert.iconv.UTF-8/ASCII//TRANSLIT');
 var_dump($reader->fetchAll());
 ~~~
@@ -180,7 +180,7 @@ echo $writer; //the newly added rows are all uppercased
 
 Please review <a href="https://github.com/thephpleague/csv/tree/8.x/examples/stream.php" target="_blank">the stream filtering example</a> and the attached <a href="https://github.com/thephpleague/csv/tree/8.x/examples/lib/FilterTranscode.php" target="_blank">FilterTranscode</a> Class to understand how to use the filtering mechanism to convert a CSV into another charset.
 
-The `FilterTranscode` class is not attached to the Library because converting your CSV may depend on the extension you choose, in PHP you can use the following extensions : 
+The `FilterTranscode` class is not attached to the Library because converting your CSV may depend on the extension you choose, in PHP you can use the following extensions :
 
 <ul>
 <li><a href="http://php.net/mbstring" target="_blank">The mbstring</a></li>

--- a/docs/8.0/index.md
+++ b/docs/8.0/index.md
@@ -17,6 +17,13 @@ layout: default
 PHP. The goal of the library is to be powerful while remaining lightweight,
 by utilizing PHP native classes whenever possible.
 
+## Notes
+
+By default, the mode for a `Reader::createFromPath()` is
+`'r+'` which looks for write permissions on the file and throws an Exception if
+the file cannot be opened with the permission set. For sake of clarity, it is
+strongly suggested to set `'r'` mode on the file to ensure it can be opened.
+
 ## Examples
 
 ### Parsing a document
@@ -28,7 +35,7 @@ A simple example to show you how to parse a CSV document.
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 //get the first row, usually the CSV header
 $headers = $csv->fetchOne();
@@ -88,7 +95,7 @@ $sth = $dbh->prepare(
 	"INSERT INTO users (firstname, lastname, email) VALUES (:firstname, :lastname, :email)"
 );
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $csv->setOffset(1); //because we don't want to insert the header
 $nbInsert = $csv->each(function ($row) use (&$sth) {
 	//Do not forget to validate your data before inserting it in your database
@@ -110,7 +117,7 @@ The below example tries to determine the encoding and convert to `UTF-8` using t
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 $input_bom = $reader->getInputBOM();
 

--- a/docs/8.0/instantiation.md
+++ b/docs/8.0/instantiation.md
@@ -60,7 +60,7 @@ The resulting string and `$open_mode` parameters are used to lazy load internall
 use League\Csv\Reader;
 use League\Csv\Writer;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 //the $reader object will use the 'r+' open mode as no `open_mode` parameter was supplied.
 $writer = Writer::createFromPath(new SplFileObject('/path/to/your/csv/file.csv', 'a+'), 'w');
 //the $writer object open mode will be 'w'!!

--- a/docs/8.0/properties.md
+++ b/docs/8.0/properties.md
@@ -46,7 +46,7 @@ public AbstractCsv::getDelimiter(void): string
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setDelimiter(';');
 $delimiter = $csv->getDelimiter(); //returns ";"
 ~~~
@@ -104,7 +104,7 @@ public AbstractCsv::getEscape(void): string
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setEscape('\\');
 $escape = $csv->getEscape(); //returns "\"
 ~~~
@@ -136,7 +136,7 @@ The method takes two arguments:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $reader->setEnclosure('"');
 $reader->setEscape('\\');
 
@@ -233,7 +233,7 @@ public AbstractCsv::getOutputBOM(void): string
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setOutputBOM(Reader::BOM_UTF8);
 $bom = $csv->getOutputBOM(); //returns "\xEF\xBB\xBF"
 ~~~
@@ -283,7 +283,7 @@ public AbstractCsv::getEncodingFrom(void): string
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setInputEncoding('iso-8859-15');
 echo $csv->getInputEncoding(); //returns iso-8859-15;
 ~~~

--- a/docs/8.0/query-filtering.md
+++ b/docs/8.0/query-filtering.md
@@ -128,7 +128,7 @@ function sortByLastName($rowA, $rowB)
     return strcmp($rowB[1], $rowA[1]);
 }
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $data = $reader
     ->stripBom(false)
     ->setOffset(3)
@@ -167,7 +167,7 @@ function sortByLastName($rowA, $rowB)
     return strcmp($rowB[1], $rowA[1]);
 }
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $data = $reader
     ->stripBom(true)
     ->setOffset(3)

--- a/docs/8.0/reading.md
+++ b/docs/8.0/reading.md
@@ -8,6 +8,13 @@ redirect_from: /reading/
 
 To extract data from a CSV document use `League\Csv\Reader` methods.
 
+## Notes
+
+By default, the mode for a `Reader::createFromPath()` is
+`'r+'` which looks for write permissions on the file and throws an Exception if
+the file cannot be opened with the permission set. For sake of clarity, it is
+strongly suggested to set `'r'` mode on the file to ensure it can be opened.
+
 ## Reader::fetch
 
 The `fetch` method fetches the next row from the `Iterator` result set.
@@ -37,7 +44,7 @@ function(array $row [, int $rowOffset [, Iterator $iterator]]): array
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $results = $reader->fetch();
 foreach ($results as $row) {
     //do something here
@@ -55,7 +62,7 @@ $func = function ($row) {
     return array_map('strtoupper', $row);
 };
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $results = $reader->fetch($func);
 foreach ($results as $row) {
     //each row member will be uppercased
@@ -95,7 +102,7 @@ The required argument `$offset` represents the row index starting at `0`. If no 
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $data = $reader->fetchOne(3); ///accessing the 4th row (indexing starts at 0)
 // will return something like this :
 //
@@ -136,7 +143,7 @@ The callable must return `true` to continue iterating over the CSV;
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 
 //count the numbers of rows in a CSV
 $nbRows = $reader->each(function ($row) {
@@ -171,7 +178,7 @@ This `$offset_or_keys` argument can be
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $keys = ['firstname', 'lastname', 'email'];
 $results = $reader->fetchAssoc($keys);
 // $results is an iterator
@@ -239,7 +246,7 @@ $func = function ($row) {
     return $row;
 };
 $keys = ['firstname', 'lastname', 'date'];
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 foreach ($reader->fetchAssoc($keys, $func) as $row) {
     $row['date']->format('Y-m-d H:i:s');
     //because this cell contain a `DateTimeInterface` object
@@ -270,7 +277,7 @@ If for a given row the column does not exist, the row will be skipped.
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $result = $reader->fetchColumn(2);
 $data = iterator_to_array($result, false);
 // will return something like this :
@@ -302,7 +309,7 @@ function(string $value [, int $offsetIndex [, Iterator $iterator]]): mixed
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 foreach ($reader->fetchColumn(2, 'strtoupper') as $value) {
     echo $value; //display 'JOHN.DOE@EXAMPLE.COM'
 }

--- a/docs/9.0/connections/bom.md
+++ b/docs/9.0/connections/bom.md
@@ -93,7 +93,7 @@ public AbstractCsv::getOutputBOM(void): string
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setOutputBOM(Reader::BOM_UTF8);
 $bom = $csv->getOutputBOM(); //returns "\xEF\xBB\xBF"
 ~~~

--- a/docs/9.0/connections/controls.md
+++ b/docs/9.0/connections/controls.md
@@ -28,7 +28,7 @@ public AbstractCsv::getDelimiter(void): string
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setDelimiter(';');
 $delimiter = $csv->getDelimiter(); //returns ";"
 ~~~
@@ -78,7 +78,7 @@ public AbstractCsv::getEscape(void): string
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setEscape('\\');
 $escape = $csv->getEscape(); //returns "\"
 ~~~
@@ -127,7 +127,7 @@ and returns an associated array whose keys are the submitted delimiters characte
 use function League\Csv\delimiter_detect;
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $reader->setEnclosure('"');
 $reader->setEscape('\\');
 

--- a/docs/9.0/connections/filters.md
+++ b/docs/9.0/connections/filters.md
@@ -30,7 +30,7 @@ Regardless of stream filter API support by a specific CSV object, `getStreamFilt
 use League\Csv\Reader;
 use League\Csv\Writer;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->supportsStreamFilter(); //return true
 $reader->getStreamFilterMode(); //return STREAM_FILTER_READ
 
@@ -81,7 +81,7 @@ use MyLib\Transcode;
 stream_filter_register('convert.utf8decode', Transcode::class);
 // 'MyLib\Transcode' is a class that extends PHP's php_user_filter class
 
-$reader = Reader::createFromPath('/path/to/my/chinese.csv');
+$reader = Reader::createFromPath('/path/to/my/chinese.csv', 'r');
 if ($reader->supportsStreamFilter()) {
 	$reader->addStreamFilter('convert.utf8decode');
 	$reader->addStreamFilter('string.toupper');

--- a/docs/9.0/connections/index.md
+++ b/docs/9.0/connections/index.md
@@ -73,7 +73,7 @@ use League\Csv\Exception;
 use League\Csv\Reader;
 
 try {
-    $csv = Reader::createFromPath('/path/to/file.csv');
+    $csv = Reader::createFromPath('/path/to/file.csv', 'r');
     $csv->setDelimiter('toto');
 } catch (Exception $e) {
     echo $e->getMessage(), PHP_EOL;

--- a/docs/9.0/connections/instantiation.md
+++ b/docs/9.0/connections/instantiation.md
@@ -48,7 +48,7 @@ use League\Csv\Reader;
 use League\Csv\Writer;
 
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $writer = Writer::createFromPath('/path/to/your/csv/file.csv', 'w');
 ~~~
 

--- a/docs/9.0/connections/output.md
+++ b/docs/9.0/connections/output.md
@@ -31,7 +31,7 @@ Use the `echo` construct on the instantiated object or use the `__toString` meth
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 echo $reader;
 // or
 echo $reader->__toString();
@@ -63,7 +63,7 @@ header('Content-Type: text/csv; charset=UTF-8');
 header('Content-Description: File Transfer');
 header('Content-Disposition: attachment; filename="name-for-your-file.csv"');
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->output();
 die;
 ~~~
@@ -125,7 +125,7 @@ To avoid breaking the flow of your application, you should create a Response obj
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 return new Response((string) $reader, 200, [
     'Content-Encoding' => 'none',
     'Content-Type' => 'text/csv; charset=UTF-8',

--- a/docs/9.0/converter/xml.md
+++ b/docs/9.0/converter/xml.md
@@ -80,7 +80,7 @@ use League\Csv\XMLConverter;
 use League\Csv\Statement;
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/prenoms.csv');
+$csv = Reader::createFromPath('/path/to/prenoms.csv', 'r');
 $csv->setDelimiter(';');
 $csv->setHeaderOffset(0);
 

--- a/docs/9.0/index.md
+++ b/docs/9.0/index.md
@@ -25,7 +25,7 @@ Accessing some records from a given CSV documents.
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $csv->setHeaderOffset(0); //set the CSV header offset
 
 //get 25 records starting from the 11th row
@@ -118,7 +118,7 @@ When importing csv files, you don't know whether the file is encoded with `UTF-8
 use League\Csv\Reader;
 use League\Csv\CharsetConverter;
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $csv->setHeaderOffset(0);
 
 $input_bom = $csv->getInputBOM();
@@ -142,7 +142,7 @@ Using the provided `XMLConverter` object you can easily convert a CSV document i
 use League\Csv\XMLConverter;
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/prenoms.csv')
+$csv = Reader::createFromPath('/path/to/prenoms.csv', 'r')
 $csv->setDelimiter(';');
 $csv->setHeaderOffset(0);
 
@@ -175,3 +175,10 @@ echo htmlentities($dom->saveXML());
 //   </record>
 // </csv>
 ~~~
+
+## Notes
+
+By default, the mode for a `Reader::createFromPath()` is
+`'r+'` which looks for write permissions on the file and throws an Exception if
+the file cannot be opened with the permission set. For sake of clarity, it is
+strongly suggested to set `'r'` mode on the file to ensure it can be opened.

--- a/docs/9.0/interoperability/encoding.md
+++ b/docs/9.0/interoperability/encoding.md
@@ -18,7 +18,7 @@ On Windows, MS Excel, expects an UTF-8 encoded CSV with its corresponding `BOM` 
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 //let's set the output BOM
 $reader->setOutputBOM(Reader::BOM_UTF8);
 //let's convert the incoming data from iso-88959-15 to utf-8

--- a/docs/9.0/interoperability/rfc4180-field.md
+++ b/docs/9.0/interoperability/rfc4180-field.md
@@ -98,7 +98,7 @@ use League\Csv\Reader;
 use League\Csv\RFC4180Field;
 
 //the current CSV is ISO-8859-15 encoded with a ";" delimiter
-$csv = Reader::createFromPath('/path/to/rfc4180-compliant.csv');
+$csv = Reader::createFromPath('/path/to/rfc4180-compliant.csv', 'r');
 RFC4180Field::addTo($csv); //adding the stream filter to fix field formatting
 
 foreach ($csv as $record) {

--- a/docs/9.0/reader/index.md
+++ b/docs/9.0/reader/index.md
@@ -53,13 +53,18 @@ public Reader::getHeader(void): array
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setHeaderOffset(0);
 $header_offset = $csv->getHeaderOffset(); //returns 0
 $header = $csv->getHeader(); //returns ['First Name', 'Last Name', 'E-mail']
 ~~~
 
 ### Notes
+
+By default, the mode for a `Reader::createFromPath()` is
+`'r+'` which looks for write permissions on the file and throws an Exception if
+the file cannot be opened with the permission set. For sake of clarity, it is
+strongly suggested to set `'r'` mode on the file to ensure it can be opened.
 
 If no header offset is set:
 
@@ -75,7 +80,7 @@ If no header offset is set:
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setHeaderOffset(1000); //valid offset but the CSV does not contain 1000 records
 $header_offset = $csv->getHeaderOffset(); //returns 1000
 $header = $csv->getHeader(); //triggers a Exception exception
@@ -101,7 +106,7 @@ The `Reader` class let's you access all its records using the `Reader::getRecord
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $records = $reader->getRecords();
 foreach ($records as $offset => $record) {
     //$offset : represents the record offset
@@ -124,7 +129,7 @@ If you specify the CSV header offset using `setHeaderOffset`, the found record w
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 $records = $reader->getRecords();
 foreach ($records as $offset => $record) {
@@ -148,7 +153,7 @@ Conversely, you can submit your own header record using the optional `$header` a
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $records = $reader->getRecords(['firstname', 'lastname', 'email']);
 foreach ($records as $offset => $record) {
     //$offset : represents the record offset
@@ -168,7 +173,7 @@ foreach ($records as $offset => $record) {
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 $records = $reader->getRecords(['firstname', 'lastname', 'email']);
 foreach ($records as $offset => $record) {
@@ -195,7 +200,7 @@ You will get the same results as if you had called `Reader::getRecords` without 
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 foreach ($reader as $offset => $record) {
     //$offset : represents the record offset
@@ -224,7 +229,7 @@ The returned records are normalized using the following rules:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 $records = $reader->getRecords();
 foreach ($records as $offset => $record) {
@@ -248,7 +253,7 @@ You can retrieve the number of records contains in a CSV document using PHP's `c
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 count($reader); //returns 4
 ~~~
 
@@ -259,7 +264,7 @@ If a header offset is specified, the number of records will not take into accoun
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 count($reader); //returns 3
 ~~~
@@ -287,7 +292,7 @@ Using method overloading, you can directly access all retrieving methods attache
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 
 $records = $reader->fetchColumn(2);
 //$records is a Generator representing all the fields of the CSV 3rd column
@@ -305,7 +310,7 @@ If you require a more advance record selection, you should use a [Statement](/9.
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $stmt = (new Statement())
     ->offset(3)
     ->limit(5)

--- a/docs/9.0/reader/resultset.md
+++ b/docs/9.0/reader/resultset.md
@@ -39,7 +39,7 @@ public ResultSet::getHeader(): array
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $records = (new Statement())->process($reader);
 $records->getHeader(); // is empty because no header information was given
 ~~~
@@ -51,7 +51,7 @@ $records->getHeader(); // is empty because no header information was given
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 
 $records = (new Statement())->process($reader);
@@ -66,7 +66,7 @@ $records->getHeader(); // returns ['First Name', 'Last Name', 'E-mail'];
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 
 $records = (new Statement())->process($reader, ['Prénom', 'Nom', 'E-mail']);
@@ -83,7 +83,7 @@ The `ResultSet` class implements implements the `Countable` interface.
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $records = (new Statement())->process($reader);
 count($records); //return the total number of records found
 ~~~
@@ -106,7 +106,7 @@ To iterate over each found records you can call the `ResultSet::getRecords` meth
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $records = (new Statement())->process($reader);
 
 foreach ($records->getRecords() as $record) {
@@ -128,7 +128,7 @@ If the `ResultSet::getHeader` is not an empty `array` the found records keys wil
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 $records = (new Statement())->process($reader);
 $records->getHeader(); //returns ['First Name', 'Last Name', 'E-mail']
@@ -161,7 +161,7 @@ The `$nth_record` argument represents the nth record contained in the result set
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 
 $stmt = (new Statement())
@@ -197,7 +197,7 @@ the `$columnIndex` parameter can be:
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $records = (new Statement())->process($reader);
 foreach ($records->fetchColumn(2) as $value) {
     //$value is a string representing the value
@@ -205,7 +205,7 @@ foreach ($records->fetchColumn(2) as $value) {
     //$value may be equal to 'john.doe@example.com'
 }
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 
 $records = (new Statement())->process($reader);
@@ -224,7 +224,7 @@ foreach ($records->fetchColumn('E-mail') as $value) {
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $records = (new Statement())->process($reader);
 count($records); //returns 10;
 count(iterator_to_array($records->fetchColumn(2), false)); //returns 5
@@ -239,7 +239,7 @@ count(iterator_to_array($records->fetchColumn(2), false)); //returns 5
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/my/file.csv');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 
 $records = (new Statement())->process($reader);

--- a/docs/9.0/reader/statement.md
+++ b/docs/9.0/reader/statement.md
@@ -119,7 +119,7 @@ function sortByLastName(array $recordA, array $recordB): int
     return strcmp($recordB[1], $recordA[1]);
 }
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $stmt = (new Statement())
     ->offset(3)
     ->limit(2)
@@ -148,7 +148,7 @@ function sortByLastName(array $recordA, array $recordB): int
     return strcmp($recordB[1], $recordA[1]);
 }
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $stmt = (new Statement())
     ->offset(3)
     ->limit(2)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ layout: homepage
 use League\Csv\Reader;
 
 //load the CSV document from a file path
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $csv->setHeaderOffset(0);
 
 $header = $csv->getHeader(); //returns the CSV header record
@@ -130,7 +130,7 @@ PHP stream filters can directly be used to ease manipulating CSV document
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/your/csv/file.csv');
+$csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $csv->setHeaderOffset(0);
 
 $input_bom = $csv->getInputBOM();

--- a/docs/upgrading/6.0.md
+++ b/docs/upgrading/6.0.md
@@ -69,7 +69,7 @@ New code:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 $delimiters_list = $reader->detectDelimiterList(10, [' ', '|']);
 if (! $delimiters_list) {
@@ -148,7 +148,7 @@ New code:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $writer = $reader->newWriter('a+');
 
 $another_writer = $writer->newWriter('rb+');

--- a/docs/upgrading/7.0.md
+++ b/docs/upgrading/7.0.md
@@ -177,7 +177,7 @@ Because prior to version 7.0 the conversion methods were not affected, you may h
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $reader->setOffset(1);
 $reader->setLimit(5);
 $reader->toHTML(); //would convert the full CSV
@@ -190,7 +190,7 @@ $reader->toHTML(); //would convert the full CSV
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $reader->setOffset(1);
 $reader->setLimit(5);
 $reader->toHTML(); //will only convert the 5 specified rows
@@ -252,7 +252,7 @@ Starting with version 7.0, each found delimiter index represents the character o
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 
 $delimiters_list = $reader->detectDelimiterList(10, [' ', '|']);
 foreach ($delimiters_list as $occurences => $delimiter) {
@@ -279,7 +279,7 @@ Prior to version 7.0 when, if the column did not exist in the csv data the metho
 use League\Csv\Reader;
 
 //this CSV contains only 2 column
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $arr = $reader->fetchColumn(3);
 //$arr is a array containing only null values;
 ~~~
@@ -292,7 +292,7 @@ $arr = $reader->fetchColumn(3);
 use League\Csv\Reader;
 
 //this CSV contains only 2 column
-$reader = Reader::createFromPath('/path/to/your/csv/file.csv');
+$reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $arr = $reader->fetchColumn(3);
 //$arr is empty
 ~~~

--- a/docs/upgrading/8.0.md
+++ b/docs/upgrading/8.0.md
@@ -75,7 +75,7 @@ The `SplFileObject` flags are normalized to have a normalized CSV filtering inde
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setFlags(SplFileObject::READ_AHEAD | SplFileObject::SKIP_EMPTY);
 $csv->fetchAssoc(); //empty lines where removed
 ~~~
@@ -87,7 +87,7 @@ $csv->fetchAssoc(); //empty lines where removed
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->fetchAssoc(); //empty lines are automatically removed
 ~~~
 
@@ -102,7 +102,7 @@ $csv->fetchAssoc(); //empty lines are automatically removed
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $res = $csv->fetchAssoc(['lastname', 'firstname']);
 
 echo $res[0]['lastname']; //would return the first row 'lastname' index
@@ -115,7 +115,7 @@ echo $res[0]['lastname']; //would return the first row 'lastname' index
 
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $res = $csv->fetchAssoc(['lastname', 'firstname']);
 
 echo iterator_to_array($res, false)[0]['lastname'];
@@ -139,7 +139,7 @@ $func = function (array $row) {
     return $row;
 };
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $res = $csv->fetchAssoc(['lastname', 'firstname'], $func);
 ~~~
 
@@ -157,7 +157,7 @@ $func = function (array $row) {
     return $row;
 };
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $res = $csv->fetchAssoc(['lastname', 'firstname'], $func);
 ~~~
 
@@ -178,7 +178,7 @@ $func = function (array $row) {
     return $row;
 };
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $res = $csv->fetchColumn(2, $func);
 ~~~
 
@@ -193,7 +193,7 @@ $func = function ($value) {
     return strtoupper($value);
 };
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $res = $csv->fetchColum(2, $func);
 ~~~
 

--- a/docs/upgrading/9.0.md
+++ b/docs/upgrading/9.0.md
@@ -132,7 +132,7 @@ Before:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 foreach ($reader->fetchAssoc() as $records) {
     //The CSV first row is implicitly used as the CSV header
     //and as the index of each found record
@@ -147,7 +147,7 @@ After:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $reader->setHeaderOffset(0); //explicitly sets the CSV document header record
 foreach ($reader->getRecords() as $records) {
     //The CSV first row is used as the CSV header
@@ -165,7 +165,7 @@ Before:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $records = $reader->fetchAssoc(['firstname', 'lastname', 'email']);
 ~~~
 
@@ -176,7 +176,7 @@ After:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $records = $reader->getRecords(['firstname', 'lastname', 'email']);
 ~~~
 
@@ -189,7 +189,7 @@ Before:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $records = $reader
     ->limit(5)
     ->offset(3)
@@ -204,7 +204,7 @@ After:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $stmt = (new Statement())
     ->limit(5)
     ->offset(3)
@@ -224,7 +224,7 @@ Before:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 foreach ($reader->fetchAll() as $key => $value) {
     // do something here
 }
@@ -237,7 +237,7 @@ After:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 foreach ($reader as $record) {
     // do something here
 }
@@ -250,7 +250,7 @@ Before:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 
 $func = function (array $record) {
     return array_map('strtoupper', $record);
@@ -275,7 +275,7 @@ After:
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $stmt = (new Statement())
     ->offset(3)
     ->limit(2)
@@ -298,7 +298,7 @@ Before:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $pairs_without_duplicates = $reader
     ->setOffset(3)
     ->setLimit(2)
@@ -318,7 +318,7 @@ After:
 use League\Csv\Reader;
 use League\Csv\Statement;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $stmt = (new Statement())
     ->offset(3)
     ->limit(2)
@@ -341,7 +341,7 @@ Before:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $stats = $reader->fetchDelimitersOccurrence([',', ';', "\t"], 10);
 ~~~
 
@@ -353,7 +353,7 @@ After:
 use League\Csv\Reader;
 use function League\Csv\delimiter_detect;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $stats = delimiter_detect($reader, [',', ';', "\t"], 10);
 ~~~
 
@@ -371,7 +371,7 @@ Before:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 $records = $reader->fetchColumn(0, function ($value) {
     return strtoupper($value);
 });
@@ -384,7 +384,7 @@ After:
 
 use League\Csv\Reader;
 
-$reader = Reader::createFromPath('/path/to/file.csv');
+$reader = Reader::createFromPath('/path/to/file.csv', 'r');
 foreach ($records->fetchColumn(0) as $value) {
     $value = strtoupper($value);
 };
@@ -514,7 +514,7 @@ After:
 use League\Csv\XMLConverter;
 use League\Csv\Reader;
 
-$csv = Reader::createFromPath('/path/to/file.csv');
+$csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $dom = (new XMLConverter())->convert($csv); //$dom is a DOMDocument
 ~~~
 


### PR DESCRIPTION
## Introduction

This updates the documentation to specify that to use the 'readonly' mode for files with the `Reader` class. I opted to update all the examples as well so we are very explicitly stating what is happening.

## Proposal 

Update documentation.

### Describe the new/upated/fixed feature

Update documentation for reader along with all the examples.

### Backward Incompatible Changes

No BC breaks

### Targeted release version

9.x

### PR Impact

Better documentation

## Open issues

#258 
