### PR TITLE
Fix incorrectly overriden static type-hint in Reader and AbstractCsv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 docs/_site
 vendor
 /nbproject/private/
+.php_cs.cache

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -155,7 +155,7 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @return static
      */
-    public static function createFromPath(string $path, string $open_mode = 'r+', $context = null): self
+    public static function createFromPath(string $path, string $open_mode = 'r+', $context = null)
     {
         return new static(Stream::createFromPath($path, $open_mode, $context));
     }

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -117,7 +117,7 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @return static
      */
-    public static function createFromFileObject(SplFileObject $file): self
+    public static function createFromFileObject(SplFileObject $file)
     {
         return new static($file);
     }
@@ -129,7 +129,7 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @return static
      */
-    public static function createFromStream($stream): self
+    public static function createFromStream($stream)
     {
         return new static(new Stream($stream));
     }
@@ -141,7 +141,7 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @return static
      */
-    public static function createFromString(string $content): self
+    public static function createFromString(string $content)
     {
         return new static(Stream::createFromString($content));
     }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -64,7 +64,7 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
     /**
      * {@inheritdoc}
      */
-    public static function createFromPath(string $path, string $open_mode = 'r', $context = null): AbstractCsv
+    public static function createFromPath(string $path, string $open_mode = 'r', $context = null)
     {
         return new static(Stream::createFromPath($path, $open_mode, $context));
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -167,7 +167,7 @@ class Stream implements SeekableIterator
      *
      * @return static
      */
-    public static function createFromPath(string $path, string $open_mode = 'r', $context = null): self
+    public static function createFromPath(string $path, string $open_mode = 'r', $context = null)
     {
         $args = [$path, $open_mode];
         if (null !== $context) {
@@ -192,7 +192,7 @@ class Stream implements SeekableIterator
      *
      * @return static
      */
-    public static function createFromString(string $content): self
+    public static function createFromString(string $content)
     {
         $resource = fopen('php://temp', 'r+');
         fwrite($resource, $content);


### PR DESCRIPTION
## Introduction

The following code produces this Phan error: `PhanUndeclaredMethod Call to undeclared method \League\Csv\AbstractCsv::setHeaderOffset`:

```php
$csvReader = Reader::createFromPath((string)$this->argument('csvPath'));
$csvReader->setHeaderOffset(0);
```

## Proposal 

Remove the static return type-hint from `AbstractCsv` since sub-classes now override `createFromPath()`.

### Backward Incompatible Changes

None

### Targeted release version

9.1.2

## Open issues

There's some references to this in https://github.com/thephpleague/csv/pull/266
