### PR TITLE
Skip using the EmptyEscapeParser polyfill on php 7.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
       env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=true RUN_PHPSTAN=true IGNORE_PLATFORMS=false
     - php: 7.2
       env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false RUN_PHPSTAN=false IGNORE_PLATFORMS=false
+    - php: 7.3
+      env: COLLECT_COVERAGE=true VALIDATE_CODING_STYLE=false RUN_PHPSTAN=false IGNORE_PLATFORMS=false
+    - php: 7.4snapshot
+      env: COLLECT_COVERAGE=false VALIDATE_CODING_STYLE=false RUN_PHPSTAN=false IGNORE_PLATFORMS=true
     - php: nightly
       env: COLLECT_COVERAGE=false VALIDATE_CODING_STYLE=false RUN_PHPSTAN=false IGNORE_PLATFORMS=true
   allow_failures:

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/ByteSequence.php
+++ b/src/ByteSequence.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/CannotInsertRecord.php
+++ b/src/CannotInsertRecord.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/CharsetConverter.php
+++ b/src/CharsetConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/ColumnConsistency.php
+++ b/src/ColumnConsistency.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/EncloseField.php
+++ b/src/EncloseField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/EscapeFormula.php
+++ b/src/EscapeFormula.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/HTMLConverter.php
+++ b/src/HTMLConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/MapIterator.php
+++ b/src/MapIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Polyfill/EmptyEscapeParser.php
+++ b/src/Polyfill/EmptyEscapeParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/RFC4180Field.php
+++ b/src/RFC4180Field.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -167,7 +167,7 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
      */
     protected function getDocument(): Iterator
     {
-        if ('' === $this->escape) {
+        if (70400 > \PHP_VERSION_ID && '' === $this->escape) {
             $this->document->setCsvControl($this->delimiter, $this->enclosure);
 
             return EmptyEscapeParser::parse($this->document);

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -265,6 +265,10 @@ class Stream implements SeekableIterator
     {
         $controls = ['delimiter' => $delimiter, 'enclosure' => $enclosure, 'escape' => $escape];
         foreach ($controls as $type => $control) {
+            if (70400 <= \PHP_VERSION_ID && 'escape' === $type && '' === $control) {
+                continue;
+            }
+
             if (1 !== strlen($control)) {
                 throw new Exception(sprintf('%s() expects %s to be a single character', $caller, $type));
             }

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/XMLConverter.php
+++ b/src/XMLConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 if (!function_exists('League\Csv\bom_match')) {
     require __DIR__.'/functions.php';
 }

--- a/tests/ByteSequenceTest.php
+++ b/tests/ByteSequenceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/CannotInsertRecordTest.php
+++ b/tests/CannotInsertRecordTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/CharsetConverterTest.php
+++ b/tests/CharsetConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/ColumnConsistencyTest.php
+++ b/tests/ColumnConsistencyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/DetectDelimiterTest.php
+++ b/tests/DetectDelimiterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/EncloseFieldTest.php
+++ b/tests/EncloseFieldTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/EscapeFormulaTest.php
+++ b/tests/EscapeFormulaTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/HTMLConverterTest.php
+++ b/tests/HTMLConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/Polyfill/EmptyEscapeParserTest.php
+++ b/tests/Polyfill/EmptyEscapeParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/RFC4180FieldTest.php
+++ b/tests/RFC4180FieldTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/ResultSetTest.php
+++ b/tests/ResultSetTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -194,6 +194,13 @@ class StreamTest extends TestCase
         $expected = [';', '|', '"'];
         $doc->setCsvControl(...$expected);
         self::assertSame($expected, $doc->getCsvControl());
+
+        if (70400 <= \PHP_VERSION_ID) {
+            $expected = [';', '|', ''];
+            $doc->setCsvControl(...$expected);
+            self::assertSame($expected, $doc->getCsvControl());
+        }
+
         self::expectException(Exception::class);
         $doc->setCsvControl(...['foo']);
     }

--- a/tests/StreamWrapper.php
+++ b/tests/StreamWrapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *

--- a/tests/XMLConverterTest.php
+++ b/tests/XMLConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * League.Csv (https://csv.thephpleague.com).
+ * League.Csv (https://csv.thephpleague.com)
  *
  * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
  *


### PR DESCRIPTION
According to https://github.com/php/php-src/commit/3b0f05119383fe21ee75adaed3d0239ba8976aef.
Embeds #329 until it's merged (see last commit only).