### PR TITLE
Allow importing the generated XML in a DOMDocument and improving  HTML converter output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "require": {
         "php" : ">=7.0.10",
-        "ext-mbstring" : "*"
+        "ext-mbstring" : "*",
+        "ext-dom" : "*"
     },
     "require-dev": {
         "ext-curl" : "*",

--- a/src/XMLConverter.php
+++ b/src/XMLConverter.php
@@ -80,11 +80,34 @@ class XMLConverter
     ];
 
     /**
-     * Convert an Record collection into a DOMDocument.
+     * Convert a Record collection into a DOMDocument.
      *
      * @param array|Traversable $records the CSV records collection
+     *
+     * @return DOMDocument
      */
     public function convert($records): DOMDocument
+    {
+        if (!is_iterable($records)) {
+            throw new TypeError(sprintf('%s() expects argument passed to be iterable, %s given', __METHOD__, gettype($records)));
+        }
+        $doc = new DOMDocument('1.0');
+        $doc->appendChild(
+            $this->import($records, $doc)
+        );
+        return $doc;
+    }
+
+    /**
+     * Create a new DOMElement related to the given DOMDocument.
+     *
+     * **DOES NOT** attach to the DOMDocument
+     *
+     * @param iterable $records
+     *
+     * @return DOMElement
+     */
+    public function import($records, DOMDocument $doc): DOMElement
     {
         if (!is_iterable($records)) {
             throw new TypeError(sprintf('%s() expects argument passed to be iterable, %s given', __METHOD__, gettype($records)));
@@ -92,15 +115,13 @@ class XMLConverter
 
         $field_encoder = $this->encoder['field']['' !== $this->column_attr];
         $record_encoder = $this->encoder['record']['' !== $this->offset_attr];
-        $doc = new DOMDocument('1.0');
         $root = $doc->createElement($this->root_name);
         foreach ($records as $offset => $record) {
             $node = $this->$record_encoder($doc, $record, $field_encoder, $offset);
             $root->appendChild($node);
         }
-        $doc->appendChild($root);
 
-        return $doc;
+        return $root;
     }
 
     /**

--- a/tests/HTMLConverterTest.php
+++ b/tests/HTMLConverterTest.php
@@ -54,6 +54,59 @@ class HTMLConverterTest extends TestCase
         self::assertContains('<table class="table-csv-data" id="test">', $html);
         self::assertContains('<tr data-record-offset="', $html);
         self::assertContains('<td title="', $html);
+        self::assertNotContains('<thead>', $html);
+        self::assertNotContains('<tbody>', $html);
+        self::assertNotContains('<tfoot>', $html);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::table
+     * @covers ::tr
+     * @covers ::td
+     * @covers ::convert
+     */
+    public function testToHTMLWithHeaders()
+    {
+        $csv = Reader::createFromPath(__DIR__.'/data/prenoms.csv', 'r')
+            ->setDelimiter(';')
+            ->setHeaderOffset(0)
+        ;
+
+        $stmt = (new Statement())
+            ->offset(3)
+            ->limit(5)
+        ;
+
+        $records = $stmt->process($csv);
+
+        $converter = (new HTMLConverter())
+            ->table('table-csv-data', 'test')
+            ->td('title')
+            ->tr('data-record-offset')
+        ;
+
+        $html = $converter->convert($records, $records->getHeader());
+        self::assertContains('<table class="table-csv-data" id="test">', $html);
+        self::assertContains('<th scope="col">prenoms</th>', $html);
+        self::assertContains('<thead>', $html);
+        self::assertContains('<tbody>', $html);
+        self::assertNotContains('<tfoot>', $html);
+
+        $html = $converter->convert($records, [], $records->getHeader());
+        self::assertContains('<table class="table-csv-data" id="test">', $html);
+        self::assertContains('<th scope="col">prenoms</th>', $html);
+        self::assertNotContains('<thead>', $html);
+        self::assertContains('<tbody>', $html);
+        self::assertContains('<tfoot>', $html);
+
+        $html = $converter->convert($records, $records->getHeader(), $records->getHeader());
+        self::assertContains('<table class="table-csv-data" id="test">', $html);
+        self::assertContains('<thead>', $html);
+        self::assertContains('<tbody>', $html);
+        self::assertContains('<tfoot>', $html);
+        self::assertNotContains('<thead><tr data-record-offset="0"></tr></thead>', $html);
+        self::assertNotContains('<tfoot><tr data-record-offset="0"></tr></tfoot>', $html);
     }
 
     /**

--- a/tests/XMLConverterTest.php
+++ b/tests/XMLConverterTest.php
@@ -12,6 +12,7 @@
 namespace LeagueTest\Csv;
 
 use DOMDocument;
+use DOMElement;
 use DOMException;
 use League\Csv\Reader;
 use League\Csv\Statement;
@@ -89,5 +90,46 @@ class XMLConverterTest extends TestCase
     {
         self::expectException(TypeError::class);
         (new XMLConverter())->convert('foo');
+    }
+
+    /**
+     * @covers ::rootElement
+     * @covers ::recordElement
+     * @covers ::fieldElement
+     * @covers ::import
+     * @covers ::recordToElement
+     * @covers ::recordToElementWithAttribute
+     * @covers ::fieldToElement
+     * @covers ::fieldToElementWithAttribute
+     * @covers ::filterAttributeName
+     * @covers ::filterElementName
+     */
+    public function testImport()
+    {
+        $csv = Reader::createFromPath(__DIR__.'/data/prenoms.csv', 'r')
+            ->setDelimiter(';')
+            ->setHeaderOffset(0)
+        ;
+
+        $stmt = (new Statement())
+            ->offset(3)
+            ->limit(5)
+        ;
+
+        $records = $stmt->process($csv);
+
+        $converter = (new XMLConverter())
+            ->rootElement('csv')
+            ->recordElement('record', 'offset')
+            ->fieldElement('field', 'name')
+        ;
+
+        $doc = new DOMDocument('1.0');
+        $element = $converter->import($records, $doc);
+
+        self::assertInstanceOf(DOMDocument::class, $doc);
+        self::assertCount(0, $doc->childNodes);
+        self::assertInstanceOf(DOMElement::class, $element);
+        self::assertCount(5, $element->childNodes);
     }
 }


### PR DESCRIPTION
In reference to #344 

Added an optional parameter to the `HTMLConverter::convert($records, $headers = null)` method.

When an array of headers is passed, the HTML table will contain a row of `<th>` elements.

The code in question goes from...

```php
$reader = Reader::createFromString($csvString);
$reader->setHeaderOffset(0);
$converter = (new HTMLConverter())
        ->table('dimensions-table')
        ->tr('data-record-offset')
        ->td('title');

$html = $converter->convert($reader);
```
and becomes...

```php
$reader = Reader::createFromString($csvString);
$reader->setHeaderOffset(0);
$converter = (new HTMLConverter())
        ->table('dimensions-table')
        ->tr('data-record-offset')
        ->td('title');

$html = $converter->convert($reader, $reader->getHeader());
```