### PR TITLE
Adding the ability to control skipping the document input BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All Notable changes to `Csv` will be documented in this file
 ### Added
 
 - Support for disabling/enabling BOM stripping via adding:
-    - `AbstractCsv::enableBOMSkipping`
-    - `AbstractCsv::disableBOMSkipping`
-    - `AbstractCsv::isBOMSkippingEnabled`
+    - `AbstractCsv::skipInputBOM`
+    - `AbstractCsv::preserveInputBOM`
+    - `AbstractCsv::isInputBOMSkipped`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All Notable changes to `Csv` will be documented in this file
 ### Added
 
 - Support for disabling/enabling BOM stripping via adding:
-    - `AbstractCsv::enableBOMStripping`
-    - `AbstractCsv::disableBOMStripping`
-    - `AbstractCsv::isBOMStrippingEnabled`
+    - `AbstractCsv::enableBOMSkipping`
+    - `AbstractCsv::disableBOMSkipping`
+    - `AbstractCsv::isBOMSkippingEnabled`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All Notable changes to `Csv` will be documented in this file
 
 ### Added
 
-- Nothing
+- Support for disabling/enabling BOM stripping via adding:
+    - `AbstractCsv::enableBOMStripping`
+    - `AbstractCsv::disableBOMStripping`
+    - `AbstractCsv::isBOMStrippingEnabled`
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,14 @@
             "@phpunit"
         ]
     },
+    "scripts-descriptions": {
+        "phpcs": "Runs coding style test suite",
+        "phpstan": "Runs complete codebase static analysis",
+        "phpstan-src": "Runs source code static analysis",
+        "phpstan-test": "Runs test suite static analysis",
+        "phpunit": "Runs unit and functional testing",
+        "test": "Runs full test suite"
+    },
     "suggest": {
         "ext-iconv" : "Needed to ease transcoding CSV using iconv stream filters"
     },

--- a/docs/9.0/connections/bom.md
+++ b/docs/9.0/connections/bom.md
@@ -76,29 +76,29 @@ $bom = $csv->getOutputBOM(); //returns "\xEF\xBB\xBF"
 <p class="message-info">The default output <code>BOM</code> character is set to an empty string.</p>
 <p class="message-warning">The output BOM sequence is <strong>never</strong> saved to the CSV document.</p>
 
-### Controlling BOM sequence removal
+### Controlling BOM sequence skipping
 
 <p class="message-info">Since version <code>9.4.0</code>.</p>
 
 ~~~php
-AbstractCsv::enableBOMStripping(): self;
-AbstractCsv::disableBOMStripping(): self;
-AbstractCsv::isBOMStrippingEnabled(): bool;
+AbstractCsv::enableBOMSkipping(): self;
+AbstractCsv::disableBOMSkipping(): self;
+AbstractCsv::isBOMSkippingEnabled(): bool;
 ~~~
 
-- `enableBOMStripping`: enables stripping the input BOM from your CSV document.
-- `disableBOMStripping`: disables stripping the input BOM from your CSV document.
-- `isBOMStrippingEnabled`: tells whether stripping the input BOM will be done.
+- `enableBOMSkipping`: enables skipping the input BOM from your CSV document.
+- `disableBOMSkipping`: disables skipping the input BOM from your CSV document.
+- `isBOMSkippingEnabled`: tells whether skipping the input BOM will be done.
 
-<p class="message-notice">By default and to avoid BC Break, BOM stripping is enabled.</p>
+<p class="message-notice">By default and to avoid BC Break, BOM skipping is enabled.</p>
 
-If your document does not contains any BOM sequence you can speed up the CSV iterator by removing the step that checks and the BOM sequence if it is present.
+If your document does not contains any BOM sequence you can speed up the CSV iterator by removing the step that ensure the BOM sequence if present is skipped.
 
 ~~~php
 $raw_csv = Reader::BOM_UTF8."john,doe,john.doe@example.com\njane,doe,jane.doe@example.com\n";
 $csv = Reader::createFromString($raw_csv);
 $csv->setOutputBOM(Reader::BOM_UTF16_BE);
-$csv->disableBOMStripping();
+$csv->disableBOMSkipping();
 ob_start();
 $csv->output();
 $document = ob_get_clean();
@@ -106,4 +106,5 @@ $document = ob_get_clean();
 
 the returned `$document` will contains **2** BOM marker instead of one.
 
-<p class="message-warning">If you are using a <code>stream</code> that can not be seekable you should disabled BOM stripping otherwise an <code>Exception</code> will be triggered.</p>
+<p class="message-warning">If you are using a <code>stream</code> that can not be seekable you should disabled BOM skipping otherwise an <code>Exception</code> will be triggered.</p>
+<p class="message-warning">The BOM sequence is never removed from the CSV document, it is only skipped from the result set.</p>

--- a/docs/9.0/connections/bom.md
+++ b/docs/9.0/connections/bom.md
@@ -76,23 +76,24 @@ $bom = $csv->getOutputBOM(); //returns "\xEF\xBB\xBF"
 <p class="message-info">The default output <code>BOM</code> character is set to an empty string.</p>
 <p class="message-warning">The output BOM sequence is <strong>never</strong> saved to the CSV document.</p>
 
-### Controlling BOM sequence skipping
+### Controlling Input BOM usage
 
 <p class="message-info">Since version <code>9.4.0</code>.</p>
 
 ~~~php
-AbstractCsv::enableBOMSkipping(): self;
-AbstractCsv::disableBOMSkipping(): self;
-AbstractCsv::isBOMSkippingEnabled(): bool;
+AbstractCsv::skipInputBOM(): self;
+AbstractCsv::preserveInputBOM(): self;
+AbstractCsv::isInputBOMSkipped(): bool;
 ~~~
 
-- `enableBOMSkipping`: enables skipping the input BOM from your CSV document.
-- `disableBOMSkipping`: disables skipping the input BOM from your CSV document.
-- `isBOMSkippingEnabled`: tells whether skipping the input BOM will be done.
+- `skipInputBOM`: enables skipping the input BOM from your CSV document.
+- `preserveInputBOM`: preserves the input BOM from your CSV document while accessing its content.
+- `isInputBOMSkipped`: tells whether skipping the input BOM will be done.
 
-<p class="message-notice">By default and to avoid BC Break, BOM skipping is enabled.</p>
+<p class="message-notice">By default and to avoid BC Break, the Input BOM is skipped.</p>
 
-If your document does not contains any BOM sequence you can speed up the CSV iterator by removing the step that ensure the BOM sequence if present is skipped.
+If your document does not contains any BOM sequence you can speed up the CSV iterator by preserving its presence which means
+ that no operation to detect and remove it if present will take place.
 
 ~~~php
 $raw_csv = Reader::BOM_UTF8."john,doe,john.doe@example.com\njane,doe,jane.doe@example.com\n";

--- a/docs/9.0/connections/bom.md
+++ b/docs/9.0/connections/bom.md
@@ -76,3 +76,34 @@ $bom = $csv->getOutputBOM(); //returns "\xEF\xBB\xBF"
 <p class="message-info">The default output <code>BOM</code> character is set to an empty string.</p>
 <p class="message-warning">The output BOM sequence is <strong>never</strong> saved to the CSV document.</p>
 
+### Controlling BOM sequence removal
+
+<p class="message-info">Since version <code>9.4.0</code>.</p>
+
+~~~php
+AbstractCsv::enableBOMStripping(): self;
+AbstractCsv::disableBOMStripping(): self;
+AbstractCsv::isBOMStrippingEnabled(): bool;
+~~~
+
+- `enableBOMStripping`: enables stripping the input BOM from your CSV document.
+- `disableBOMStripping`: disables stripping the input BOM from your CSV document.
+- `isBOMStrippingEnabled`: tells whether stripping the input BOM will be done.
+
+<p class="message-notice">By default and to avoid BC Break, BOM stripping is enabled.</p>
+
+If your document does not contains any BOM sequence you can speed up the CSV iterator by removing the step that checks and the BOM sequence if it is present.
+
+~~~php
+$raw_csv = Reader::BOM_UTF8."john,doe,john.doe@example.com\njane,doe,jane.doe@example.com\n";
+$csv = Reader::createFromString($raw_csv);
+$csv->setOutputBOM(Reader::BOM_UTF16_BE);
+$csv->disableBOMStripping();
+ob_start();
+$csv->output();
+$document = ob_get_clean();
+~~~
+
+the returned `$document` will contains **2** BOM marker instead of one.
+
+<p class="message-warning">If you are using a <code>stream</code> that can not be seekable you should disabled BOM stripping otherwise an <code>Exception</code> will be triggered.</p>

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -89,11 +89,11 @@ abstract class AbstractCsv implements ByteSequence
     protected $document;
 
     /**
-     * Tells whether the BOM must be stripped.
+     * Tells whether the Input BOM must be stripped.
      *
      * @var bool
      */
-    protected $is_BOM_skipping_enabled = true;
+    protected $is_input_bom_skipped = true;
 
     /**
      * New instance.
@@ -257,9 +257,9 @@ abstract class AbstractCsv implements ByteSequence
     /**
      * Tells whether the BOM can be stripped if presents.
      */
-    public function isBOMSkippingEnabled(): bool
+    public function isInputBOMSkipped(): bool
     {
-        return $this->is_BOM_skipping_enabled;
+        return $this->is_input_bom_skipped;
     }
 
     /**
@@ -327,7 +327,7 @@ abstract class AbstractCsv implements ByteSequence
         }
 
         $this->document->rewind();
-        if ($this->is_BOM_skipping_enabled) {
+        if ($this->is_input_bom_skipped) {
             $this->document->fseek(strlen($this->getInputBOM()));
         }
 
@@ -443,21 +443,21 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @return static
      */
-    public function enableBOMSkipping(): self
+    public function skipInputBOM(): self
     {
-        $this->is_BOM_skipping_enabled = true;
+        $this->is_input_bom_skipped = true;
 
         return $this;
     }
 
     /**
-     * Disables BOM Stripping.
+     * Disables skipping Input BOM.
      *
      * @return static
      */
-    public function disableBOMSkipping(): self
+    public function preserveInputBOM(): self
     {
-        $this->is_BOM_skipping_enabled = false;
+        $this->is_input_bom_skipped = false;
 
         return $this;
     }

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -89,6 +89,13 @@ abstract class AbstractCsv implements ByteSequence
     protected $document;
 
     /**
+     * Tells whether the BOM must be stripped.
+     *
+     * @var bool
+     */
+    protected $is_enable_BOM_stripping = true;
+
+    /**
      * New instance.
      *
      * @param SplFileObject|Stream $document The CSV Object instance
@@ -248,6 +255,14 @@ abstract class AbstractCsv implements ByteSequence
     }
 
     /**
+     * Tells whether the BOM can be stripped if presents.
+     */
+    public function isBOMStrippingEnabled(): bool
+    {
+        return $this->is_enable_BOM_stripping;
+    }
+
+    /**
      * Retuns the CSV document as a Generator of string chunk.
      *
      * @param int $length number of bytes read
@@ -310,9 +325,12 @@ abstract class AbstractCsv implements ByteSequence
         if (null !== $filename) {
             $this->sendHeaders($filename);
         }
-        $input_bom = $this->getInputBOM();
+
         $this->document->rewind();
-        $this->document->fseek(strlen($input_bom));
+        if ($this->is_enable_BOM_stripping) {
+            $this->document->fseek(strlen($this->getInputBOM()));
+        }
+
         echo $this->output_bom;
 
         return strlen($this->output_bom) + $this->document->fpassthru();
@@ -418,6 +436,30 @@ abstract class AbstractCsv implements ByteSequence
         }
 
         throw new Exception(sprintf('%s() expects escape to be a single character or the empty string %s given', __METHOD__, $escape));
+    }
+
+    /**
+     * Enables BOM Stripping.
+     *
+     * @return static
+     */
+    public function enableBOMStripping(): self
+    {
+        $this->is_enable_BOM_stripping = true;
+
+        return $this;
+    }
+
+    /**
+     * Disables BOM Stripping.
+     *
+     * @return static
+     */
+    public function disableBOMStripping(): self
+    {
+        $this->is_enable_BOM_stripping = false;
+
+        return $this;
     }
 
     /**

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -93,7 +93,7 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @var bool
      */
-    protected $is_enable_BOM_stripping = true;
+    protected $is_BOM_skipping_enabled = true;
 
     /**
      * New instance.
@@ -257,9 +257,9 @@ abstract class AbstractCsv implements ByteSequence
     /**
      * Tells whether the BOM can be stripped if presents.
      */
-    public function isBOMStrippingEnabled(): bool
+    public function isBOMSkippingEnabled(): bool
     {
-        return $this->is_enable_BOM_stripping;
+        return $this->is_BOM_skipping_enabled;
     }
 
     /**
@@ -327,7 +327,7 @@ abstract class AbstractCsv implements ByteSequence
         }
 
         $this->document->rewind();
-        if ($this->is_enable_BOM_stripping) {
+        if ($this->is_BOM_skipping_enabled) {
             $this->document->fseek(strlen($this->getInputBOM()));
         }
 
@@ -443,9 +443,9 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @return static
      */
-    public function enableBOMStripping(): self
+    public function enableBOMSkipping(): self
     {
-        $this->is_enable_BOM_stripping = true;
+        $this->is_BOM_skipping_enabled = true;
 
         return $this;
     }
@@ -455,9 +455,9 @@ abstract class AbstractCsv implements ByteSequence
      *
      * @return static
      */
-    public function disableBOMStripping(): self
+    public function disableBOMSkipping(): self
     {
-        $this->is_enable_BOM_stripping = false;
+        $this->is_BOM_skipping_enabled = false;
 
         return $this;
     }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -268,7 +268,7 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
         };
 
         $bom = '';
-        if ($this->is_enable_BOM_stripping) {
+        if ($this->is_BOM_skipping_enabled) {
             $bom = $this->getInputBOM();
         }
 

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -266,9 +266,13 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
         $normalized = static function ($record): bool {
             return is_array($record) && $record != [null];
         };
-        $bom = $this->getInputBOM();
-        $document = $this->getDocument();
 
+        $bom = '';
+        if ($this->is_enable_BOM_stripping) {
+            $bom = $this->getInputBOM();
+        }
+
+        $document = $this->getDocument();
         $records = $this->stripBOM(new CallbackFilterIterator($document, $normalized), $bom);
         if (null !== $this->header_offset) {
             $records = new CallbackFilterIterator($records, function (array $record, int $offset): bool {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -268,7 +268,7 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
         };
 
         $bom = '';
-        if ($this->is_BOM_skipping_enabled) {
+        if ($this->is_input_bom_skipped) {
             $bom = $this->getInputBOM();
         }
 

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -461,18 +461,18 @@ EOF;
     }
 
     /**
-     * @covers ::isBOMStrippingEnabled
-     * @covers ::disableBOMStripping
-     * @covers ::enableBOMStripping
+     * @covers ::isBOMSkippingEnabled
+     * @covers ::disableBOMSkipping
+     * @covers ::enableBOMSkipping
      */
     public function testBOMStripping()
     {
         $reader = Reader::createFromString();
-        self::assertTrue($reader->isBOMStrippingEnabled());
-        $reader->disableBOMStripping();
-        self::assertFalse($reader->isBOMStrippingEnabled());
-        $reader->enableBOMStripping();
-        self::assertTrue($reader->isBOMStrippingEnabled());
+        self::assertTrue($reader->isBOMSkippingEnabled());
+        $reader->disableBOMSkipping();
+        self::assertFalse($reader->isBOMSkippingEnabled());
+        $reader->enableBOMSkipping();
+        self::assertTrue($reader->isBOMSkippingEnabled());
     }
 
     /**
@@ -490,7 +490,7 @@ EOF;
         self::assertNotContains(Reader::BOM_UTF8, $result);
         self::assertContains(Reader::BOM_UTF16_BE, $result);
 
-        $csv->disableBOMStripping();
+        $csv->disableBOMSkipping();
         ob_start();
         $csv->output();
         $result = ob_get_clean();

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -440,8 +440,8 @@ EOF;
                 'expected' => 'tests/data/foo.csv',
             ],
             'external uri' => [
-                'path' => 'https://raw.githubusercontent.com/thephpleague/csv/8.x/test/data/foo.csv',
-                'expected' => 'https://raw.githubusercontent.com/thephpleague/csv/8.x/test/data/foo.csv',
+                'path' => 'https://raw.githubusercontent.com/thephpleague/csv/8.2.3/test/data/foo.csv',
+                'expected' => 'https://raw.githubusercontent.com/thephpleague/csv/8.2.3/test/data/foo.csv',
             ],
         ];
     }
@@ -461,18 +461,18 @@ EOF;
     }
 
     /**
-     * @covers ::isBOMSkippingEnabled
-     * @covers ::disableBOMSkipping
-     * @covers ::enableBOMSkipping
+     * @covers ::isInputBOMSkipped
+     * @covers ::preserveInputBOM
+     * @covers ::skipInputBOM
      */
     public function testBOMStripping()
     {
         $reader = Reader::createFromString();
-        self::assertTrue($reader->isBOMSkippingEnabled());
-        $reader->disableBOMSkipping();
-        self::assertFalse($reader->isBOMSkippingEnabled());
-        $reader->enableBOMSkipping();
-        self::assertTrue($reader->isBOMSkippingEnabled());
+        self::assertTrue($reader->isInputBOMSkipped());
+        $reader->preserveInputBOM();
+        self::assertFalse($reader->isInputBOMSkipped());
+        $reader->skipInputBOM();
+        self::assertTrue($reader->isInputBOMSkipped());
     }
 
     /**
@@ -490,7 +490,7 @@ EOF;
         self::assertNotContains(Reader::BOM_UTF8, $result);
         self::assertContains(Reader::BOM_UTF16_BE, $result);
 
-        $csv->disableBOMSkipping();
+        $csv->preserveInputBOM();
         ob_start();
         $csv->output();
         $result = ob_get_clean();

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -334,7 +334,7 @@ EOF;
         $fp = fopen('php://temp', 'r+');
         fputcsv($fp, $expected_record);
         $csv = Reader::createFromStream($fp);
-        $csv->disableBOMSkipping();
+        $csv->preserveInputBOM();
         self::assertSame(Reader::BOM_UTF16_LE, $csv->getInputBOM());
         foreach ($csv as $offset => $record) {
             self::assertSame($expected_record, $record);

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -334,7 +334,7 @@ EOF;
         $fp = fopen('php://temp', 'r+');
         fputcsv($fp, $expected_record);
         $csv = Reader::createFromStream($fp);
-        $csv->disableBOMStripping();
+        $csv->disableBOMSkipping();
         self::assertSame(Reader::BOM_UTF16_LE, $csv->getInputBOM());
         foreach ($csv as $offset => $record) {
             self::assertSame($expected_record, $record);

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -328,6 +328,22 @@ EOF;
         }
     }
 
+    public function testDisablingBOMStripping()
+    {
+        $expected_record = [Reader::BOM_UTF16_LE.'john', 'doe', 'john.doe@example.com'];
+        $fp = fopen('php://temp', 'r+');
+        fputcsv($fp, $expected_record);
+        $csv = Reader::createFromStream($fp);
+        $csv->disableBOMStripping();
+        self::assertSame(Reader::BOM_UTF16_LE, $csv->getInputBOM());
+        foreach ($csv as $offset => $record) {
+            self::assertSame($expected_record, $record);
+        }
+        $csv = null;
+        fclose($fp);
+        $fp = null;
+    }
+
     /**
      * @covers ::getIterator
      * @dataProvider appliedFlagsProvider


### PR DESCRIPTION
This PR resolves issue #352 by re-introducing a way to control if BOM stripping should be done. This helps resolving the issue of processing stream resource that can not be seekable. 

**Of note, if your stream is not seekable you can still not detect its input BOM**

