### PR TITLE
Adding the ability to control skipping empty records by the Reader class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All Notable changes to `Csv` will be documented in this file
 
 ### Added
 
-- Nothing
+- Adding support for controlling empty record presence in `Reader::getRecords` return value.
+    - `Reader::preserveEmptyRecord`
+    - `Reader::skipEmptyRecord`
+    - `Reader::isEmptyRecordSkipped`
 
 ### Deprecated
 

--- a/src/Polyfill/EmptyEscapeParser.php
+++ b/src/Polyfill/EmptyEscapeParser.php
@@ -117,7 +117,7 @@ final class EmptyEscapeParser
         self::$document->rewind();
         while (self::$document->valid()) {
             $record = self::extractRecord();
-            if (!in_array(null, $record, true)) {
+            if ([null] === $record || !in_array(null, $record, true)) {
                 yield $record;
             }
         }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -398,7 +398,7 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
     /**
      * Enable skipping empty records.
      */
-    public function enableEmptyRecordsSkipping(): self
+    public function skipEmptyRecord(): self
     {
         if (!$this->is_empty_records_skipped) {
             $this->is_empty_records_skipped = true;
@@ -411,7 +411,7 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
     /**
      * Disable skipping empty records.
      */
-    public function disableEmptyRecordsSkipping(): self
+    public function preserveEmptyRecord(): self
     {
         if ($this->is_empty_records_skipped) {
             $this->is_empty_records_skipped = false;
@@ -424,7 +424,7 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
     /**
      * Tells whether empty records are skipped by the instance.
      */
-    public function isEmptyRecordsSkipped(): bool
+    public function isEmptyRecordSkipped(): bool
     {
         return $this->is_empty_records_skipped;
     }

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -438,8 +438,8 @@ EOF;
                 'expected' => 'tests/data/foo.csv',
             ],
             'external uri' => [
-                'path' => 'https://raw.githubusercontent.com/thephpleague/csv/8.x/test/data/foo.csv',
-                'expected' => 'https://raw.githubusercontent.com/thephpleague/csv/8.x/test/data/foo.csv',
+                'path' => 'https://raw.githubusercontent.com/thephpleague/csv/8.2.3/test/data/foo.csv',
+                'expected' => 'https://raw.githubusercontent.com/thephpleague/csv/8.2.3/test/data/foo.csv',
             ],
         ];
     }

--- a/tests/Polyfill/EmptyEscapeParserTest.php
+++ b/tests/Polyfill/EmptyEscapeParserTest.php
@@ -100,7 +100,7 @@ EOF;
      * @covers ::extractFieldContent
      * @covers ::extractEnclosedFieldContent
      */
-    public function testRemoveEmptyLines()
+    public function testPreserveEmptyLines()
     {
         $source = <<<EOF
 "parent name","child name","title"
@@ -114,6 +114,8 @@ EOF;
 
         $expected = [
             ['parent name', 'child name', 'title'],
+            [null],
+            [null],
             ['parentA', 'childA', 'titleA'],
         ];
 

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -486,6 +486,8 @@ EOF;
         foreach ($reader as $offset => $record) {
             self::assertSame($expected_with_skipping[$offset], $record);
         }
+
+        unset($reader);
     }
 
     public function sourceProvider(): array
@@ -497,17 +499,15 @@ EOF;
 "parentA","childA","titleA"
 EOF;
         $expected_with_no_skipping = [
-            ['parent name', 'child name', 'title'],
-            [],
-            [],
-            ['parentA', 'childA', 'titleA'],
+            0 => ['parent name', 'child name', 'title'],
+            1 => [],
+            2 => [],
+            3 => ['parentA', 'childA', 'titleA'],
         ];
 
         $expected_with_skipping = [
-            ['parent name', 'child name', 'title'],
-            [],
-            [],
-            ['parentA', 'childA', 'titleA'],
+            0 => ['parent name', 'child name', 'title'],
+            3 => ['parentA', 'childA', 'titleA'],
         ];
 
         $rsrc = new SplTempFileObject();


### PR DESCRIPTION
This PR adds the ability in the Reader class to control if empty records should be skipped or not. By default and to avoid BC break empty records are skipped. The result of `Reader::getRecords` will be controlled by the following methods.

- `Reader::preserveEmptyRecord`
- `Reader::skipEmptyRecord`
- `Reader::isEmptyRecordSkipped`
