### PR TITLE
Fatal error with ltrim() when using the EmptyEscapeParser

### DIFF
--- a/src/Polyfill/EmptyEscapeParser.php
+++ b/src/Polyfill/EmptyEscapeParser.php
@@ -150,12 +150,13 @@ final class EmptyEscapeParser
     private static function extractRecord(): array
     {
         $record = [];
-        if (false === (self::$line = self::$document->fgets())) {
-            return [null];
-        }
+        self::$line = self::$document->fgets();
         do {
             $method = 'extractFieldContent';
-            $buffer = ltrim(self::$line, self::$trim_mask);
+            $buffer = '';
+            if (false !== self::$line) {
+                $buffer = ltrim(self::$line, self::$trim_mask);
+            }
             if (($buffer[0] ?? '') === self::$enclosure) {
                 $method = 'extractEnclosedFieldContent';
                 self::$line = $buffer;

--- a/src/Polyfill/EmptyEscapeParser.php
+++ b/src/Polyfill/EmptyEscapeParser.php
@@ -150,8 +150,7 @@ final class EmptyEscapeParser
     private static function extractRecord(): array
     {
         $record = [];
-        self::$line = self::$document->fgets();
-        if (self::$line === false) {
+        if (false === (self::$line = self::$document->fgets())) {
             return [null];
         }
         do {

--- a/src/Polyfill/EmptyEscapeParser.php
+++ b/src/Polyfill/EmptyEscapeParser.php
@@ -151,6 +151,9 @@ final class EmptyEscapeParser
     {
         $record = [];
         self::$line = self::$document->fgets();
+        if (self::$line === false) {
+            return [null];
+        }
         do {
             $method = 'extractFieldContent';
             $buffer = ltrim(self::$line, self::$trim_mask);

--- a/tests/Polyfill/EmptyEscapeParserTest.php
+++ b/tests/Polyfill/EmptyEscapeParserTest.php
@@ -132,25 +132,15 @@ EOF;
      */
     public function testReadingOnlyStream()
     {
-        $source = <<<EOF
-"1","2"
-
-EOF;
-
         $expected = [
-            ['1', '2'],
+            ['john', 'doe', 'john.doe@example.com'],
             [null],
         ];
 
-        $path = sys_get_temp_dir().'/test.csv';
-        file_put_contents($path, $source);
-
-        $stream = Stream::createFromPath($path);
+        $stream = Stream::createFromPath(__DIR__.'/../data/foo_readonly.csv');
         foreach (EmptyEscapeParser::parse($stream) as $offset => $record) {
             self::assertSame($expected[$offset], $record);
         }
-
-        unlink($path);
     }
 
     /**

--- a/tests/Polyfill/EmptyEscapeParserTest.php
+++ b/tests/Polyfill/EmptyEscapeParserTest.php
@@ -138,11 +138,11 @@ EOF;
 EOF;
 
         $expected = [
-            ['1','2'],
-            [null]
+            ['1', '2'],
+            [null],
         ];
 
-        $path = sys_get_temp_dir() . '/test.csv';
+        $path = sys_get_temp_dir().'/test.csv';
         file_put_contents($path, $source);
 
         $stream = Stream::createFromPath($path);

--- a/tests/Polyfill/EmptyEscapeParserTest.php
+++ b/tests/Polyfill/EmptyEscapeParserTest.php
@@ -130,6 +130,34 @@ EOF;
      * @covers ::extractFieldContent
      * @covers ::extractEnclosedFieldContent
      */
+    public function testReadingOnlyStream()
+    {
+        $source = <<<EOF
+"1","2"
+
+EOF;
+
+        $expected = [
+            ['1','2'],
+        ];
+
+        $path = sys_get_temp_dir() . '/test.csv';
+        file_put_contents($path, $source);
+
+        $stream = Stream::createFromPath($path);
+        foreach (EmptyEscapeParser::parse($stream) as $offset => $record) {
+            self::assertSame($expected[$offset], $record);
+        }
+
+        unlink($path);
+    }
+
+    /**
+     * @covers ::parse
+     * @covers ::extractRecord
+     * @covers ::extractFieldContent
+     * @covers ::extractEnclosedFieldContent
+     */
     public function testNoTrimmedSpaceWithNotEncloseField()
     {
         $source = <<<EOF

--- a/tests/Polyfill/EmptyEscapeParserTest.php
+++ b/tests/Polyfill/EmptyEscapeParserTest.php
@@ -139,6 +139,7 @@ EOF;
 
         $expected = [
             ['1','2'],
+            [null]
         ];
 
         $path = sys_get_temp_dir() . '/test.csv';


### PR DESCRIPTION
When calling `$csv->setEscape('');` I've noticed that when the last line of my read-only CSV created from path was empty the following error would occur:

> Fatal error: Uncaught TypeError: ltrim() expects parameter 1 to be string, boolean given in [...]vendor/league/csv/src/Polyfill/EmptyEscapeParser.php on line 156

I believe this to be down to differences between the `SplFileObject` and `League\Csv\Stream` implementations. For the empty line `fgets()` on a `SplFileObject` returns `''` but using the procedural style or `League\Csv\Stream`, `false` is returned:

```php
$path = sys_get_temp_dir().'/test.csv';
file_put_contents($path, '"1","2"' . "\n");

$fh = new SplFileObject($path, 'r');
$fh->fgets();
var_dump($fh->fgets()); // '' is returned

$fh = fopen($path, 'r');
fgets($fh);
var_dump(fgets($fh)); // false is returned

$fh = League\Csv\Stream::createFromPath($path);
$fh->fgets();
var_dump($fh->fgets()); // false is returned

unlink($path);
```

I'm not sure this pull request contains the best way to rectify the issue but tests are passing and if nothing else this can start a discussion.