### PR TITLE
Introducing the TabularDataReader interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ All Notable changes to `Csv` will be documented in this file
 - More return types and type parameters as supported in PHP7.2+
 - `League\Csv\Statement::create` named constructor to ease constraint builder instantiation
 - `League\Csv\Statement` can now also process `League\Csv\ResultSet` instances.
-- `League\Csv\ResultSet::getRecords` has an optional `$header` second argument to make the method works like `League\Csv\Reader::getRecords` 
 - `League\Csv\TabularDataReader` interface to represent how to read tabular data
+- `League\Csv\ResultSet::getRecords` has an optional `$header` second argument to make the method works like `League\Csv\Reader::getRecords` 
+- `League\Csv\ResultSet::createFromReader` create a new instance from `League\Csv\Reader` 
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All Notable changes to `Csv` will be documented in this file
 ### Added
 
 - More return types and type parameters as supported in PHP7.2+
+- `League\Csv\Statement::create` named constructor to ease constraint builder instantiation
+- `League\Csv\Statement` can now also process `League\Csv\ResultSet` instances.
+- `League\Csv\ResultSet::getRecords` has an optional `$header` second argument to make the method works like `League\Csv\Reader::getRecords` 
+- `League\Csv\TabularDataReader` interface to represent how to read tabular data
 
 ### Deprecated
 
@@ -14,7 +18,7 @@ All Notable changes to `Csv` will be documented in this file
 
 ### Fixed
 
-- Nothing
+- `League\Csv\Reader` no longer uses `__call` to implement `fetchOne`, `fetchPairs` and `fetchColumn` methods.
 
 ### Removed
 

--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -9,8 +9,5 @@ parameters:
           path: tests/DetectDelimiterTest.php
         - message: '#Parameter \#1 \$document of static method League\\Csv\\Polyfill\\EmptyEscapeParser::parse\(\) expects League\\Csv\\Stream\|SplFileObject, stdClass given.#'
           path: tests/Polyfill/EmptyEscapeParserTest.php
-        - message: '#Parameter \#1 \$records of method League\\Csv\\Statement::process\(\) expects League\\Csv\\Reader\|League\\Csv\\ResultSet, stdClass given.#'
-          path: tests/ResultSetTest.php
-
     reportUnmatchedIgnoredErrors: true
     checkMissingIterableValueType: false

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -199,9 +199,7 @@ class Reader extends AbstractCsv implements TabularDataReader, JsonSerializable
      */
     public function fetchColumn($index = 0): Iterator
     {
-        $tabular_data = new ResultSet($this->getRecords(), $this->getHeader());
-
-        return $tabular_data->fetchColumn($index);
+        return ResultSet::createFromReader($this)->fetchColumn($index);
     }
 
     /**
@@ -209,9 +207,7 @@ class Reader extends AbstractCsv implements TabularDataReader, JsonSerializable
      */
     public function fetchOne(int $nth_record = 0): array
     {
-        $tabular_data = new ResultSet($this->getRecords(), $this->getHeader());
-
-        return $tabular_data->fetchOne($nth_record);
+        return ResultSet::createFromReader($this)->fetchOne($nth_record);
     }
 
     /**
@@ -219,9 +215,7 @@ class Reader extends AbstractCsv implements TabularDataReader, JsonSerializable
      */
     public function fetchPairs($offset_index = 0, $value_index = 1): Iterator
     {
-        $tabular_data = new ResultSet($this->getRecords(), $this->getHeader());
-
-        return $tabular_data->fetchPairs($offset_index, $value_index);
+        return ResultSet::createFromReader($this)->fetchPairs($offset_index, $value_index);
     }
 
     /**
@@ -253,18 +247,7 @@ class Reader extends AbstractCsv implements TabularDataReader, JsonSerializable
     }
 
     /**
-     * Returns the CSV records as an iterator object.
-     *
-     * Each CSV record is represented as a simple array containing strings or null values.
-     *
-     * If the CSV document has a header record then each record is combined
-     * to the header record and the header record is removed from the iterator.
-     *
-     * If the CSV document is inconsistent. Missing record fields are
-     * filled with null values while extra record fields are strip from
-     * the returned object.
-     *
-     * @param string[] $header an optional header to use instead of the CSV document header
+     * {@inheritDoc}
      */
     public function getRecords(array $header = []): Iterator
     {

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -13,12 +13,8 @@ declare(strict_types=1);
 
 namespace League\Csv;
 
-use BadMethodCallException;
 use CallbackFilterIterator;
-use Countable;
-use Generator;
 use Iterator;
-use IteratorAggregate;
 use JsonSerializable;
 use League\Csv\Polyfill\EmptyEscapeParser;
 use SplFileObject;
@@ -41,12 +37,8 @@ use const STREAM_FILTER_READ;
 
 /**
  * A class to parse and read records from a CSV document.
- *
- * @method array fetchOne(int $nth_record = 0) Returns a single record from the CSV
- * @method Generator fetchColumn(string|int $column_index) Returns the next value from a single CSV record field
- * @method Generator fetchPairs(string|int $offset_index = 0, string|int $value_index = 1) Fetches the next key-value pairs from the CSV document
  */
-class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSerializable
+class Reader extends AbstractCsv implements TabularDataReader, JsonSerializable
 {
     /**
      * header offset.
@@ -109,11 +101,7 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
     }
 
     /**
-     * Returns the CSV record used as header.
-     *
-     * The returned header is represented as an array of string values
-     *
-     * @return string[]
+     * {@inheritDoc}
      */
     public function getHeader(): array
     {
@@ -153,7 +141,6 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
 
     /**
      * Returns the row at a given offset.
-     *
      */
     protected function seekRow(int $offset): array
     {
@@ -210,14 +197,31 @@ class Reader extends AbstractCsv implements Countable, IteratorAggregate, JsonSe
     /**
      * {@inheritdoc}
      */
-    public function __call(string $method, array $arguments)
+    public function fetchColumn($index = 0): Iterator
     {
-        static $whitelisted = ['fetchColumn' => 1, 'fetchOne' => 1, 'fetchPairs' => 1];
-        if (isset($whitelisted[$method])) {
-            return (new ResultSet($this->getRecords(), $this->getHeader()))->$method(...$arguments);
-        }
+        $tabular_data = new ResultSet($this->getRecords(), $this->getHeader());
 
-        throw new BadMethodCallException(sprintf('%s::%s() method does not exist', static::class, $method));
+        return $tabular_data->fetchColumn($index);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchOne(int $nth_record = 0): array
+    {
+        $tabular_data = new ResultSet($this->getRecords(), $this->getHeader());
+
+        return $tabular_data->fetchOne($nth_record);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchPairs($offset_index = 0, $value_index = 1): Iterator
+    {
+        $tabular_data = new ResultSet($this->getRecords(), $this->getHeader());
+
+        return $tabular_data->fetchPairs($offset_index, $value_index);
     }
 
     /**

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -14,10 +14,7 @@ declare(strict_types=1);
 namespace League\Csv;
 
 use CallbackFilterIterator;
-use Countable;
-use Generator;
 use Iterator;
-use IteratorAggregate;
 use JsonSerializable;
 use LimitIterator;
 use function array_flip;
@@ -30,7 +27,7 @@ use function sprintf;
 /**
  * Represents the result set of a {@link Reader} processed by a {@link Statement}.
  */
-class ResultSet implements Countable, IteratorAggregate, JsonSerializable
+class ResultSet implements TabularDataReader, JsonSerializable
 {
     /**
      * The CSV records collection.
@@ -51,8 +48,9 @@ class ResultSet implements Countable, IteratorAggregate, JsonSerializable
      */
     public function __construct(Iterator $records, array $header)
     {
-        $this->records = $records;
         $this->validateHeader($header);
+
+        $this->records = $records;
         $this->header = $header;
     }
 
@@ -87,7 +85,7 @@ class ResultSet implements Countable, IteratorAggregate, JsonSerializable
     /**
      * {@inheritdoc}
      */
-    public function getIterator(): Generator
+    public function getIterator(): Iterator
     {
         return $this->getRecords();
     }
@@ -95,7 +93,7 @@ class ResultSet implements Countable, IteratorAggregate, JsonSerializable
     /**
      * {@inheritdoc}
      */
-    public function getRecords(array $header = []): Generator
+    public function getRecords(array $header = []): Iterator
     {
         $this->validateHeader($header);
         $records = $this->combineHeader($header);
@@ -145,13 +143,7 @@ class ResultSet implements Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
-     * Returns the nth record from the result set.
-     *
-     * By default if no index is provided the first record of the resultet is returned
-     *
-     * @param int $nth_record the CSV record offset
-     *
-     * @throws Exception if argument is lesser than 0
+     * {@inheritdoc}
      */
     public function fetchOne(int $nth_record = 0): array
     {
@@ -166,13 +158,9 @@ class ResultSet implements Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
-     * Returns a single column from the next record of the result set.
-     *
-     * By default if no value is supplied the first column is fetch
-     *
-     * @param string|int $index CSV column index
+     * {@inheritdoc}
      */
-    public function fetchColumn($index = 0): Generator
+    public function fetchColumn($index = 0): Iterator
     {
         $offset = $this->getColumnIndex($index, __METHOD__.'() expects the column index to be a valid string or integer, `%s` given');
         $filter = static function (array $record) use ($offset): bool {
@@ -246,17 +234,9 @@ class ResultSet implements Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
-     * Returns the next key-value pairs from a result set (first
-     * column is the key, second column is the value).
-     *
-     * By default if no column index is provided:
-     * - the first column is used to provide the keys
-     * - the second column is used to provide the value
-     *
-     * @param string|int $offset_index The column index to serve as offset
-     * @param string|int $value_index  The column index to serve as value
+     * {@inheritdoc}
      */
-    public function fetchPairs($offset_index = 0, $value_index = 1): Generator
+    public function fetchPairs($offset_index = 0, $value_index = 1): Iterator
     {
         $offset = $this->getColumnIndex($offset_index, __METHOD__.'() expects the offset index value to be a valid string or integer, `%s` given');
         $value = $this->getColumnIndex($value_index, __METHOD__.'() expects the value index value to be a valid string or integer, `%s` given');

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -73,6 +73,14 @@ class ResultSet implements TabularDataReader, JsonSerializable
     }
 
     /**
+     * Returns a new instance from a League\Csv\Reader object.
+     */
+    public static function createFromReader(Reader $reader): self
+    {
+        return new self($reader->getRecords(), $reader->getHeader());
+    }
+
+    /**
      * Returns the header associated with the result set.
      *
      * @return string[]

--- a/src/Statement.php
+++ b/src/Statement.php
@@ -17,7 +17,6 @@ use ArrayIterator;
 use CallbackFilterIterator;
 use Iterator;
 use LimitIterator;
-use TypeError;
 use function array_reduce;
 
 /**
@@ -71,10 +70,10 @@ class Statement
     /**
      * Set the Iterator filter method.
      */
-    public function where(callable $callable): self
+    public function where(callable $where): self
     {
         $clone = clone $this;
-        $clone->where[] = $callable;
+        $clone->where[] = $where;
 
         return $clone;
     }
@@ -82,10 +81,10 @@ class Statement
     /**
      * Set an Iterator sorting callable function.
      */
-    public function orderBy(callable $callable): self
+    public function orderBy(callable $order_by): self
     {
         $clone = clone $this;
-        $clone->order_by[] = $callable;
+        $clone->order_by[] = $order_by;
 
         return $clone;
     }
@@ -135,26 +134,15 @@ class Statement
     /**
      * Execute the prepared Statement on the {@link Reader} object.
      *
-     * @param Reader|ResultSet $records
-     * @param string[]         $header  an optional header to use instead of the CSV document header
+     * @param string[] $header an optional header to use instead of the CSV document header
      */
-    public function process($records, array $header = []): ResultSet
+    public function process(TabularDataReader $tabular_data, array $header = []): TabularDataReader
     {
-        if (!($records instanceof Reader) && !($records instanceof ResultSet)) {
-            throw new TypeError(sprintf(
-                '%s expects parameter 1 to be a %s or a %s object, %s given',
-                __METHOD__,
-                ResultSet::class,
-                Reader::class,
-                get_class($records)
-            ));
-        }
-
         if ([] === $header) {
-            $header = $records->getHeader();
+            $header = $tabular_data->getHeader();
         }
 
-        $iterator = $records->getRecords($header);
+        $iterator = $tabular_data->getRecords($header);
         $iterator = array_reduce($this->where, [$this, 'filter'], $iterator);
         $iterator = $this->buildOrderBy($iterator);
 

--- a/src/TabularDataReader.php
+++ b/src/TabularDataReader.php
@@ -23,30 +23,10 @@ use IteratorAggregate;
 interface TabularDataReader extends Countable, IteratorAggregate
 {
     /**
-     * Returns the header associated with the tabular data.
-     *
-     * The header must contains unique string or is an empty array
-     * if no header was specified.
-     *
-     * @return string[]
+     * Returns the number of records contained in the tabular data structure
+     * excluding the header record.
      */
-    public function getHeader(): array;
-
-    /**
-     * Returns the tabular data records as an iterator object.
-     *
-     * Each record is represented as a simple array containing strings or null values.
-     *
-     * If the CSV document has a header record then each record is combined
-     * to the header record and the header record is removed from the iterator.
-     *
-     * If the CSV document is inconsistent. Missing record fields are
-     * filled with null values while extra record fields are strip from
-     * the returned object.
-     *
-     * @param string[] $header an optional header to use instead of the CSV document header
-     */
-    public function getRecords(array $header = []): Iterator;
+    public function count(): int;
 
     /**
      * Returns the tabular data records as an iterator object.
@@ -63,9 +43,30 @@ interface TabularDataReader extends Countable, IteratorAggregate
     public function getIterator(): Iterator;
 
     /**
-     * Returns the number of records contained in the tabular data structure.
+     * Returns the header associated with the tabular data.
+     *
+     * The header must contains unique string or is an empty array
+     * if no header was specified.
+     *
+     * @return string[]
      */
-    public function count(): int;
+    public function getHeader(): array;
+
+    /**
+     * Returns the tabular data records as an iterator object.
+     *
+     * Each record is represented as a simple array containing strings or null values.
+     *
+     * If the tabular data has a header record then each record is combined
+     * to the header record and the header record is removed from the iterator.
+     *
+     * If the tabular data is inconsistent. Missing record fields are
+     * filled with null values while extra record fields are strip from
+     * the returned object.
+     *
+     * @param string[] $header an optional header to use instead of the CSV document header
+     */
+    public function getRecords(array $header = []): Iterator;
 
     /**
      * Returns the nth record from the tabular data.

--- a/src/TabularDataReader.php
+++ b/src/TabularDataReader.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * League.Csv (https://csv.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\Csv;
+
+use Countable;
+use Iterator;
+use IteratorAggregate;
+
+/**
+ * Represents a Tabular data.
+ */
+interface TabularDataReader extends Countable, IteratorAggregate
+{
+    /**
+     * Returns the header associated with the tabular data.
+     *
+     * The header must contains unique string or is an empty array
+     * if no header was specified.
+     *
+     * @return string[]
+     */
+    public function getHeader(): array;
+
+    /**
+     * Returns the tabular data records as an iterator object.
+     *
+     * Each record is represented as a simple array containing strings or null values.
+     *
+     * If the CSV document has a header record then each record is combined
+     * to the header record and the header record is removed from the iterator.
+     *
+     * If the CSV document is inconsistent. Missing record fields are
+     * filled with null values while extra record fields are strip from
+     * the returned object.
+     *
+     * @param string[] $header an optional header to use instead of the CSV document header
+     */
+    public function getRecords(array $header = []): Iterator;
+
+    /**
+     * Returns the tabular data records as an iterator object.
+     *
+     * Each record is represented as a simple array containing strings or null values.
+     *
+     * If the CSV document has a header record then each record is combined
+     * to the header record and the header record is removed from the iterator.
+     *
+     * If the CSV document is inconsistent. Missing record fields are
+     * filled with null values while extra record fields are strip from
+     * the returned object.
+     */
+    public function getIterator(): Iterator;
+
+    /**
+     * Returns the number of records contained in the tabular data structure.
+     */
+    public function count(): int;
+
+    /**
+     * Returns the nth record from the tabular data.
+     *
+     * By default if no index is provided the first record of the tabular data is returned
+     *
+     * @param int $nth_record the tabular data record offset
+     *
+     * @throws Exception if argument is lesser than 0
+     */
+    public function fetchOne(int $nth_record = 0): array;
+
+    /**
+     * Returns a single column from the next record of the tabular data.
+     *
+     * By default if no value is supplied the first column is fetch
+     *
+     * @param string|int $index CSV column index
+     */
+    public function fetchColumn($index = 0): Iterator;
+
+    /**
+     * Returns the next key-value pairs from the tabular data (first
+     * column is the key, second column is the value).
+     *
+     * By default if no column index is provided:
+     * - the first column is used to provide the keys
+     * - the second column is used to provide the value
+     *
+     * @param string|int $offset_index The column index to serve as offset
+     * @param string|int $value_index  The column index to serve as value
+     */
+    public function fetchPairs($offset_index = 0, $value_index = 1): Iterator;
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -69,12 +69,12 @@ function delimiter_detect(Reader $csv, array $delimiters, int $limit = 1): array
         return count($record) > 1;
     };
 
-    $stmt = (new Statement())->limit($limit);
+    $stmt = Statement::create(null, 0, $limit);
 
     $delimiter_stats = static function (array $stats, string $delimiter) use ($csv, $stmt, $record_filter): array {
         $csv->setDelimiter($delimiter);
         $found_records = array_filter(
-            iterator_to_array($stmt->process($csv), false),
+            iterator_to_array($stmt->process($csv)->getRecords(), false),
             $record_filter
         );
 

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -11,7 +11,6 @@
 
 namespace LeagueTest\Csv;
 
-use BadMethodCallException;
 use League\Csv\Exception;
 use League\Csv\Reader;
 use League\Csv\Statement;
@@ -164,7 +163,9 @@ EOF;
     }
 
     /**
-     * @covers ::__call
+     * @covers ::fetchColumn
+     * @covers ::fetchOne
+     * @covers ::fetchPairs
      */
     public function testCall(): void
     {
@@ -187,26 +188,6 @@ EOF;
         self::assertEquals($csv->fetchOne(3), $res->fetchOne(3));
         self::assertEquals($csv->fetchColumn('firstname'), $res->fetchColumn('firstname'));
         self::assertEquals($csv->fetchPairs('lastname', 0), $res->fetchPairs('lastname', 0));
-    }
-
-    /**
-     * @covers ::__call
-     *
-     * @param string $method
-     * @dataProvider invalidMethodCallMethodProvider
-     */
-    public function testCallThrowsException($method): void
-    {
-        self::expectException(BadMethodCallException::class);
-        $this->csv->$method();
-    }
-
-    public function invalidMethodCallMethodProvider(): iterable
-    {
-        return [
-            'unknown method' => ['foo'],
-            'ResultSet method not whitelisted' => ['isRecordOffsetPreserved'],
-        ];
     }
 
     /**

--- a/tests/ResultSetTest.php
+++ b/tests/ResultSetTest.php
@@ -20,8 +20,6 @@ use League\Csv\SyntaxError;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 use SplTempFileObject;
-use stdClass;
-use TypeError;
 use function array_reverse;
 use function current;
 use function in_array;
@@ -114,13 +112,6 @@ class ResultSetTest extends TestCase
         $stmt_alt = $this->stmt->limit(-1)->offset(0);
 
         self::assertSame($stmt_alt, $this->stmt);
-    }
-
-    public function testProcessThrowsOnUnsupportedFormat(): void
-    {
-        self::expectException(TypeError::class);
-        $stmt = Statement::create();
-        $stmt->process(new stdClass());
     }
 
     /**


### PR DESCRIPTION
Introducing the `TabularDataReader` interface to unify the `Reader` and the `ResultSet` classes.