### PR TITLE
fix CI for PHP 8.0

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -10,13 +10,9 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ '7.2', '7.3', '7.4' ]
+                php: [ '7.2', '7.3', '7.4', '8.0' ]
                 composer-flags: [ '' ]
                 phpunit-flags: [ '--coverage-text' ]
-                include:
-                    - php: '8.0'
-                      composer-flags: '--ignore-platform-req=php'
-                      phpunit-flags: '--no-coverage'
         steps:
             - uses: actions/checkout@v2
             - uses: shivammathur/setup-php@v2

--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -9,11 +9,5 @@ parameters:
           path: tests/DetectDelimiterTest.php
         - message: '#Parameter \#1 \$document of static method League\\Csv\\Polyfill\\EmptyEscapeParser::parse\(\) expects League\\Csv\\Stream\|SplFileObject, stdClass given.#'
           path: tests/Polyfill/EmptyEscapeParserTest.php
-        - message: '#Call to function iterator_to_array\(\) on a separate line has no effect.#'
-          path: tests/ResultSetTest.php
-        - message: '#Call to function iterator_to_array\(\) on a separate line has no effect.#'
-          path: tests/ReaderTest.php
-        - message: '#Call to function iterator_to_array\(\) on a separate line has no effect.#'
-          path: tests/CsvTest.php
     reportUnmatchedIgnoredErrors: true
     checkMissingIterableValueType: false


### PR DESCRIPTION
Fixes #404 - `iterator_to_array` is not marked as pure anymore: https://github.com/JetBrains/phpstorm-stubs/pull/969
Checks are still run on PHP 7.4 because PHP 8.0 introduces `false` return type for `createElement` and other DOM-related methods - I will try to provide a fix in a separate PR soon.