### PR TITLE
do not allow for output during tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
@@ -8,6 +10,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         beStrictAboutOutputDuringTests="true"
          processIsolation="false"
          stopOnFailure="false">
 

--- a/tests/CharsetConverterTest.php
+++ b/tests/CharsetConverterTest.php
@@ -37,7 +37,7 @@ class CharsetConverterTest extends TestCase
      */
     public function testCharsetConverterTriggersException(): void
     {
-        self::expectException(OutOfRangeException::class);
+        $this->expectException(OutOfRangeException::class);
         (new CharsetConverter())->inputEncoding('');
     }
 
@@ -131,7 +131,7 @@ class CharsetConverterTest extends TestCase
      */
     public function testCharsetConverterAsStreamFilterFailed(): void
     {
-        self::expectException(InvalidArgument::class);
+        $this->expectException(InvalidArgument::class);
         stream_filter_register(CharsetConverter::FILTERNAME.'.*', CharsetConverter::class);
         $expected = 'Batman,Superman,Anaïs';
         $raw = mb_convert_encoding($expected, 'iso-8859-15', 'utf-8');

--- a/tests/ColumnConsistencyTest.php
+++ b/tests/ColumnConsistencyTest.php
@@ -70,7 +70,7 @@ class ColumnConsistencyTest extends TestCase
      */
     public function testColumnsCount(): void
     {
-        self::expectException(CannotInsertRecord::class);
+        $this->expectException(CannotInsertRecord::class);
         $this->csv->addValidator(new ColumnConsistency(3), 'consistency');
         $this->csv->insertOne(['john', 'doe', 'john.doe@example.com']);
         $this->csv->insertOne(['jane', 'jane.doe@example.com']);
@@ -82,7 +82,7 @@ class ColumnConsistencyTest extends TestCase
      */
     public function testColumsCountTriggersException(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         new ColumnConsistency(-2);
     }
 }

--- a/tests/CsvTest.php
+++ b/tests/CsvTest.php
@@ -88,7 +88,7 @@ class CsvTest extends TestCase
      */
     public function testCreateFromPathThrowsRuntimeException(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         Reader::createFromPath(__DIR__.'/foo/bar', 'r');
     }
 
@@ -125,7 +125,7 @@ EOF;
      */
     public function testCloningIsForbidden(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         clone $this->csv;
     }
 
@@ -136,7 +136,10 @@ EOF;
      */
     public function testOutputSize(): void
     {
-        self::assertSame(60, $this->csv->output('test.csv'));
+        ob_start();
+        $length = $this->csv->output('test.csv');
+        ob_end_clean();
+        self::assertSame(60, $length);
     }
 
     /**
@@ -146,7 +149,7 @@ EOF;
      */
     public function testInvalidOutputFile(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->csv->output('invalid/file.csv');
     }
 
@@ -165,7 +168,9 @@ EOF;
 
         $raw_csv = Reader::BOM_UTF8."john,doe,john.doe@example.com\njane,doe,jane.doe@example.com\n";
         $csv = Reader::createFromString($raw_csv);
+        ob_start();
         $csv->output('tést.csv');
+        ob_end_clean();
         $headers = xdebug_get_headers();
 
         // Due to the variety of ways the xdebug expresses Content-Type of text files,
@@ -203,7 +208,7 @@ EOF;
      */
     public function testChunkTriggersException(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $chunk = $this->csv->chunk(0);
         iterator_to_array($chunk);
     }
@@ -235,7 +240,7 @@ EOF;
      */
     public function testDelimiter(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->csv->setDelimiter('o');
         self::assertSame('o', $this->csv->getDelimiter());
         self::assertSame($this->csv, $this->csv->setDelimiter('o'));
@@ -286,7 +291,7 @@ EOF;
      */
     public function testEscape(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->csv->setEscape('o');
         self::assertSame('o', $this->csv->getEscape());
         self::assertSame($this->csv, $this->csv->setEscape('o'));
@@ -300,7 +305,7 @@ EOF;
      */
     public function testEnclosure(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->csv->setEnclosure('o');
         self::assertSame('o', $this->csv->getEnclosure());
         self::assertSame($this->csv, $this->csv->setEnclosure('o'));
@@ -330,7 +335,7 @@ EOF;
      */
     public function testFailedAddStreamFilter(): void
     {
-        self::expectException(UnavailableFeature::class);
+        $this->expectException(UnavailableFeature::class);
         $csv = Writer::createFromFileObject(new SplTempFileObject());
         self::assertFalse($csv->supportsStreamFilter());
         $csv->addStreamFilter('string.toupper');
@@ -343,7 +348,7 @@ EOF;
      */
     public function testFailedAddStreamFilterWithWrongFilter(): void
     {
-        self::expectException(InvalidArgument::class);
+        $this->expectException(InvalidArgument::class);
         /** @var resource $tmpfile */
         $tmpfile = tmpfile();
         $csv = Writer::createFromStream($tmpfile);

--- a/tests/DetectDelimiterTest.php
+++ b/tests/DetectDelimiterTest.php
@@ -28,7 +28,7 @@ class DetectDelimiterTest extends TestCase
         $file = new SplTempFileObject();
         $file->fwrite("How are you today ?\nI'm doing fine thanks!");
         $csv = Reader::createFromFileObject($file);
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         delimiter_detect($csv, [','], -4);
     }
 
@@ -37,7 +37,7 @@ class DetectDelimiterTest extends TestCase
         $file = new SplTempFileObject();
         $file->fwrite("How are you today ?\nI'm doing fine thanks!");
         $csv = Reader::createFromFileObject($file);
-        self::expectException(TypeError::class);
+        $this->expectException(TypeError::class);
         delimiter_detect($csv, [',', []]);
     }
 

--- a/tests/EncloseFieldTest.php
+++ b/tests/EncloseFieldTest.php
@@ -86,7 +86,7 @@ class EncloseFieldTest extends TestCase
      */
     public function testEncloseFieldImmutability(): void
     {
-        self::expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $csv = Writer::createFromString('');
         $csv->setDelimiter('|');
         EncloseField::addTo($csv, 'foo');

--- a/tests/EscapeFormulaTest.php
+++ b/tests/EscapeFormulaTest.php
@@ -30,7 +30,7 @@ class EscapeFormulaTest extends TestCase
      */
     public function testConstructorThrowsTypError(): void
     {
-        self::expectException(TypeError::class);
+        $this->expectException(TypeError::class);
         new EscapeFormula("\t", [(object) 'i']);
     }
 
@@ -41,7 +41,7 @@ class EscapeFormulaTest extends TestCase
      */
     public function testConstructorThrowsInvalidArgumentException(): void
     {
-        self::expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         new EscapeFormula("\t", ['i', 'foo']);
     }
 

--- a/tests/HTMLConverterTest.php
+++ b/tests/HTMLConverterTest.php
@@ -173,7 +173,7 @@ class HTMLConverterTest extends TestCase
      */
     public function testTableTriggersException(): void
     {
-        self::expectException(DOMException::class);
+        $this->expectException(DOMException::class);
         (new HTMLConverter())->table('table-csv-data', 'te st');
     }
 }

--- a/tests/Polyfill/EmptyEscapeParserTest.php
+++ b/tests/Polyfill/EmptyEscapeParserTest.php
@@ -32,7 +32,7 @@ class EmptyEscapeParserTest extends TestCase
      */
     public function testConstructorThrowsTypeErrorWithUnknownDocument(): void
     {
-        self::expectException(TypeError::class);
+        $this->expectException(TypeError::class);
         $records = EmptyEscapeParser::parse(new stdClass());
         $records->rewind();
     }

--- a/tests/RFC4180FieldTest.php
+++ b/tests/RFC4180FieldTest.php
@@ -99,7 +99,7 @@ class RFC4180FieldTest extends TestCase
      */
     public function testOnCreateFailedWithoutParams(): void
     {
-        self::expectException(TypeError::class);
+        $this->expectException(TypeError::class);
         (new RFC4180Field())->onCreate();
     }
 
@@ -183,7 +183,7 @@ class RFC4180FieldTest extends TestCase
      */
     public function testDoNotEncloseWhiteSpacedFieldThrowsException(): void
     {
-        self::expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         RFC4180Field::addTo(Writer::createFromString(''), "\t\0");
     }
 }

--- a/tests/ReaderTest.php
+++ b/tests/ReaderTest.php
@@ -199,7 +199,7 @@ EOF;
      */
     public function testHeaderThrowsExceptionOnError(): void
     {
-        self::expectException(SyntaxError::class);
+        $this->expectException(SyntaxError::class);
         $csv = Reader::createFromString(
             'field1,field1,field3
             1,2,3
@@ -218,7 +218,7 @@ EOF;
      */
     public function testHeaderThrowsExceptionOnEmptyLine(): void
     {
-        self::expectException(SyntaxError::class);
+        $this->expectException(SyntaxError::class);
         $str = <<<EOF
 foo,bar,baz
 
@@ -363,7 +363,7 @@ EOF;
      */
     public function testGetHeaderThrowsExceptionWithNegativeOffset(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->csv->setHeaderOffset(-3)->getRecords();
     }
 
@@ -373,7 +373,7 @@ EOF;
      */
     public function testGetHeaderThrowsExceptionWithSplFileObject(): void
     {
-        self::expectException(SyntaxError::class);
+        $this->expectException(SyntaxError::class);
         $this->csv->setHeaderOffset(23)->getRecords();
     }
 
@@ -383,7 +383,7 @@ EOF;
      */
     public function testGetHeaderThrowsExceptionWithStreamObject(): void
     {
-        self::expectException(SyntaxError::class);
+        $this->expectException(SyntaxError::class);
 
         /** @var resource $tmp */
         $tmp = fopen('php://temp', 'r+');
@@ -400,7 +400,7 @@ EOF;
      */
     public function testSetHeaderThrowsExceptionOnWrongInputRange(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->csv->setHeaderOffset(-1);
     }
 
@@ -621,7 +621,7 @@ CSV;
         $csv = Reader::createFromString($text);
         $csv->setHeaderOffset(0);
 
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $csv->getHeader();
     }
 }

--- a/tests/ResultSetTest.php
+++ b/tests/ResultSetTest.php
@@ -85,7 +85,7 @@ class ResultSetTest extends TestCase
      */
     public function testSetOffsetThrowsException(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->stmt->offset(-1);
     }
 
@@ -119,7 +119,7 @@ class ResultSetTest extends TestCase
      */
     public function testSetLimitThrowException(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->stmt->limit(-4);
     }
 
@@ -174,7 +174,7 @@ class ResultSetTest extends TestCase
      */
     public function testIntervalThrowException(): void
     {
-        self::expectException(OutOfBoundsException::class);
+        $this->expectException(OutOfBoundsException::class);
         iterator_to_array($this->stmt
             ->offset(1)
             ->limit(0)
@@ -256,7 +256,7 @@ class ResultSetTest extends TestCase
      */
     public function testFetchColumnTriggersException($field): void
     {
-        self::expectException(InvalidArgument::class);
+        $this->expectException(InvalidArgument::class);
         $this->csv->setHeaderOffset(0);
         $res = $this->stmt->process($this->csv)->fetchColumn($field);
         iterator_to_array($res, false);
@@ -277,7 +277,7 @@ class ResultSetTest extends TestCase
      */
     public function testFetchColumnTriggersOutOfRangeException(): void
     {
-        self::expectException(InvalidArgument::class);
+        $this->expectException(InvalidArgument::class);
         $this->csv->setHeaderOffset(0);
         $res = $this->stmt->process($this->csv)->fetchColumn(-1);
         iterator_to_array($res, false);
@@ -398,7 +398,7 @@ class ResultSetTest extends TestCase
      */
     public function testFetchOneTriggersException(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->stmt->process($this->csv)->fetchOne(-5);
     }
 
@@ -515,7 +515,7 @@ class ResultSetTest extends TestCase
      */
     public function testHeaderThrowsExceptionOnError(): void
     {
-        self::expectException(SyntaxError::class);
+        $this->expectException(SyntaxError::class);
         $csv = Reader::createFromString(
             'field1,field1,field3
             1,2,3

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -47,7 +47,7 @@ class StreamTest extends TestCase
      */
     public function testCloningIsForbidden(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $toto = clone new Stream(fopen('php://temp', 'r+'));
     }
 
@@ -56,7 +56,7 @@ class StreamTest extends TestCase
      */
     public function testCreateStreamWithInvalidParameter(): void
     {
-        self::expectException(TypeError::class);
+        $this->expectException(TypeError::class);
         new Stream(__DIR__.'/data/foo.csv');
     }
 
@@ -65,7 +65,7 @@ class StreamTest extends TestCase
      */
     public function testCreateStreamWithWrongResourceType(): void
     {
-        self::expectException(TypeError::class);
+        $this->expectException(TypeError::class);
         new Stream(curl_init());
     }
 
@@ -75,8 +75,8 @@ class StreamTest extends TestCase
     public function testCreateStreamFromPath(): void
     {
         $path = 'no/such/file.csv';
-        self::expectException(Exception::class);
-        self::expectExceptionMessage('`'.$path.'`: failed to open stream: No such file or directory');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('`'.$path.'`: failed to open stream: No such file or directory');
         Stream::createFromPath($path);
     }
 
@@ -116,7 +116,7 @@ class StreamTest extends TestCase
      */
     public function testfputcsv(string $delimiter, string $enclosure, string $escape): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $stream = new Stream(fopen('php://temp', 'r+'));
         $stream->fputcsv(['john', 'doe', 'john.doe@example.com'], $delimiter, $enclosure, $escape);
     }
@@ -144,7 +144,7 @@ class StreamTest extends TestCase
      */
     public function testSeekThrowsException(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $stream = new Stream(fopen('php://temp', 'r+'));
         $stream->seek(-1);
     }
@@ -177,7 +177,7 @@ class StreamTest extends TestCase
      */
     public function testRewindThrowsException(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $stream = new Stream(fopen('php://stdin', 'r'));
         $stream->rewind();
     }
@@ -187,7 +187,7 @@ class StreamTest extends TestCase
      */
     public function testCreateStreamWithNonSeekableStream(): void
     {
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $stream = new Stream(fopen('php://stdin', 'r'));
         $stream->seek(3);
     }
@@ -204,7 +204,7 @@ class StreamTest extends TestCase
         $expected = [';', '|', '"'];
         $doc->setCsvControl(...$expected);
         self::assertSame($expected, $doc->getCsvControl());
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $doc->setCsvControl(...['foo']);
     }
 
@@ -213,7 +213,7 @@ class StreamTest extends TestCase
         if (70400 <= PHP_VERSION_ID) {
             $this->markTestSkipped('This test is only for PHP7.4- versions');
         }
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $doc = Stream::createFromString();
         $doc->setCsvControl(...[';', '|', '']);
     }
@@ -235,8 +235,8 @@ class StreamTest extends TestCase
     public function testAppendStreamFilterThrowsException(): void
     {
         $filtername = 'foo.bar';
-        self::expectException(InvalidArgument::class);
-        self::expectExceptionMessage('unable to locate filter `'.$filtername.'`');
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage('unable to locate filter `'.$filtername.'`');
         $stream = Stream::createFromPath('php://temp', 'r+');
         $stream->appendFilter($filtername, STREAM_FILTER_READ);
     }

--- a/tests/WriterTest.php
+++ b/tests/WriterTest.php
@@ -63,7 +63,7 @@ class WriterTest extends TestCase
     public function testflushThresholdThrowsException(): void
     {
         $this->csv->setFlushThreshold(1);
-        self::expectException(Exception::class);
+        $this->expectException(Exception::class);
         $this->csv->setFlushThreshold(0);
     }
 
@@ -117,11 +117,11 @@ class WriterTest extends TestCase
     public function testInsertThrowsExceptionOnError(array $record): void
     {
         if (70400 > PHP_VERSION_ID) {
-            self::expectException(CannotInsertRecord::class);
-            self::expectExceptionMessage('Unable to write record to the CSV document');
+            $this->expectException(CannotInsertRecord::class);
+            $this->expectExceptionMessage('Unable to write record to the CSV document');
         } else {
             self::expectNotice();
-            self::expectExceptionMessageMatches('/write of \d+ bytes failed with errno=9 Bad file descriptor/i');
+            $this->expectExceptionMessageMatches('/write of \d+ bytes failed with errno=9 Bad file descriptor/i');
         }
 
         Writer::createFromPath(__DIR__.'/data/foo.csv', 'r')->insertOne($record);
@@ -206,7 +206,7 @@ class WriterTest extends TestCase
             return false;
         };
 
-        self::expectException(CannotInsertRecord::class);
+        $this->expectException(CannotInsertRecord::class);
         $this->csv->addValidator($func, 'func1');
         $this->csv->insertOne(['jane', 'doe']);
     }
@@ -227,8 +227,8 @@ class WriterTest extends TestCase
      */
     public function testWriterTriggerExceptionWithNonSeekableStream(): void
     {
-        self::expectException(Exception::class);
-        $writer = Writer::createFromPath('php://output', 'w');
+        $this->expectException(Exception::class);
+        $writer = Writer::createFromPath('php://null', 'w');
         $writer->setNewline("\r\n");
         $writer->insertOne(['foo', 'bar']);
     }

--- a/tests/XMLConverterTest.php
+++ b/tests/XMLConverterTest.php
@@ -86,7 +86,7 @@ class XMLConverterTest extends TestCase
      */
     public function testXmlElementTriggersException(): void
     {
-        self::expectException(DOMException::class);
+        $this->expectException(DOMException::class);
         (new XMLConverter())
             ->recordElement('record', '')
             ->rootElement('   ');


### PR DESCRIPTION
This PR restricts output during test and suppressed existing tests with output.
It also uses `$this->expectException()` instead of `self::expectException()` calls as the method is not static.