### PR TITLE
Adding AbstractCsv::toString method to prepare 10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ All Notable changes to `Csv` will be documented in this file
 
 - `League\Csv\Info::fetchDelimiters` to replace the namespace function `delimiter_detect`
 - `League\Csv\Info::fetchBOMSequence` to replace the namespace function `bom_match`
+- `League\Csv\AbstractCsv::toString` to replace `League\Csv\AbstractCsv::getContent` and `League\Csv\AbstractCsv::__toString`
 
 ### Deprecated
 
 - `League\Csv\delimiter_detect` use `League\Csv\Info::getDelimiterStats`
 - `League\Csv\bom_match` use `League\Csv\Info::fetchBOMSequence`
+- `League\Csv\AbstractCsv::getContent` use `League\Csv\AbstractCsv::toString`
 
 ### Fixed
 

--- a/docs/9.0/connections/output.md
+++ b/docs/9.0/connections/output.md
@@ -17,13 +17,15 @@ The output methods **are affected by** [the output BOM sequence](/9.0/connection
 Returns the string representation of the CSV document
 
 ~~~php
+public AbstractCsv::toString(void): string
 public AbstractCsv::getContent(void): string
 public AbstractCsv::__toString(void): string
 ~~~
 
+<p class="message-notice">The <code>toString</code> method is added in version <code>9.7.0</code> and replaces the <code>getContent</code> method which is <strong>deprecated</strong>.</p>
 <p class="message-notice">The <code>getContent</code> method is added in version <code>9.1.0</code> and replaces the <code>__toString</code> method which is <strong>deprecated</strong>.</p>
 
-Use the `getContent` method to return the CSV full content.
+Use the `toString` method to return the CSV full content.
 
 ### Example
 
@@ -31,25 +33,25 @@ Use the `getContent` method to return the CSV full content.
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
-echo $reader->getContent();
+echo $reader->toString();
 ~~~
 
 ### Exceptions and Errors
 
 If the CSV document is not seekable a `Exception` or a `RuntimeException` may be thrown when using `getContent`. A `Fatal Error` will be trigger when using the `__toString` method.
 
-#### Using the `getContent` method
+#### Using the `toString` method
 
 ~~~php
 use League\Csv\Writer;
 
 $csv = Writer::createFromFileObject('php://output', 'w');
 $csv->insertOne(['foo', 'bar']);
-echo $csv->getContent();
+echo $csv->toString();
 //throws an RuntimeException because the SplFileObject is not seekable
 ~~~
 
-#### Using the `__toString` method
+#### Using the `__toString` or `getContent` methods
 
 ~~~php
 use League\Csv\Writer;
@@ -57,6 +59,7 @@ use League\Csv\Writer;
 $csv = Writer::createFromFileObject('php://output', 'w');
 $csv->insertOne(['foo', 'bar']);
 echo $csv;
+echo $csv->getContent();
 //throws a Fatal Error because no exception can be thrown by the __toString method
 ~~~
 

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -295,19 +295,34 @@ abstract class AbstractCsv implements ByteSequence
      * DEPRECATION WARNING! This method will be removed in the next major point release.
      *
      * @deprecated deprecated since version 9.1.0
-     * @see AbstractCsv::getContent
+     * @see AbstractCsv::toString
      *
      * Retrieves the CSV content
      */
     public function __toString(): string
     {
-        return $this->getContent();
+        return $this->toString();
     }
 
     /**
      * Retrieves the CSV content.
+     *
+     * DEPRECATION WARNING! This method will be removed in the next major point release
+     *
+     * @deprecated deprecated since version 9.7.0
+     * @see AbstractCsv::toString
      */
     public function getContent(): string
+    {
+        return $this->toString();
+    }
+
+    /**
+     * Retrieves the CSV content.
+     *
+     * @throws Exception If the string representation can not be returned
+     */
+    public function toString(): string
     {
         $raw = '';
         foreach ($this->chunk(8192) as $chunk) {


### PR DESCRIPTION
To prepare 10.0.0 release anytime whenever it will be released. We are deprecated all methods that returns the string representation of the CSV and only exposing it using the explicit `toString`.

