### PR TITLE
fix 8.x docs urls, as 8.x cannot be open anymore

### DIFF
--- a/docs/8.0/bom.md
+++ b/docs/8.0/bom.md
@@ -155,4 +155,4 @@ $csv->output('mycsvfile.csv');
 
 Of note, we used the [filtering capability](/8.0/filtering) of the library to convert the CSV encoding character from `UTF-8` to `UTF-16 LE`.
 
-You can found the code and the associated filter class in the [examples directory](https://github.com/thephpleague/csv/tree/8.x/examples).
+You can found the code and the associated filter class in the [examples directory](https://github.com/thephpleague/csv/tree/8.2.3/examples).

--- a/docs/8.0/examples.md
+++ b/docs/8.0/examples.md
@@ -112,15 +112,15 @@ foreach ($reader->fetchAssoc(0) as $row) {
 
 ## More Examples
 
-* [Selecting specific rows in the CSV](https://github.com/thephpleague/csv/tree/8.x/examples/extract.php)
-* [Querying a CSV](https://github.com/thephpleague/csv/tree/8.x/examples/filtering.php)
-* [Creating a CSV](https://github.com/thephpleague/csv/tree/8.x/examples/writing.php)
-* [Merging 2 CSV documents](https://github.com/thephpleague/csv/tree/8.x/examples/merge.php)
-* [Switching between modes from Writer to Reader mode](https://github.com/thephpleague/csv/tree/8.x/examples/switchmode.php)
-* [Downloading the CSV](https://github.com/thephpleague/csv/tree/8.x/examples/download.php)
-* [Converting the CSV into a Json String](https://github.com/thephpleague/csv/tree/8.x/examples/json.php)
-* [Converting the CSV into a XML file](https://github.com/thephpleague/csv/tree/8.x/examples/xml.php)
-* [Converting the CSV into a HTML Table](https://github.com/thephpleague/csv/tree/8.x/examples/table.php)
-* [Using stream Filter on the CSV](https://github.com/thephpleague/csv/tree/8.x/examples/stream.php)
+* [Selecting specific rows in the CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/extract.php)
+* [Querying a CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/filtering.php)
+* [Creating a CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/writing.php)
+* [Merging 2 CSV documents](https://github.com/thephpleague/csv/tree/8.2.3/examples/merge.php)
+* [Switching between modes from Writer to Reader mode](https://github.com/thephpleague/csv/tree/8.2.3/examples/switchmode.php)
+* [Downloading the CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/download.php)
+* [Converting the CSV into a Json String](https://github.com/thephpleague/csv/tree/8.2.3/examples/json.php)
+* [Converting the CSV into a XML file](https://github.com/thephpleague/csv/tree/8.2.3/examples/xml.php)
+* [Converting the CSV into a HTML Table](https://github.com/thephpleague/csv/tree/8.2.3/examples/table.php)
+* [Using stream Filter on the CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/stream.php)
 
 > The CSV data use for the examples are taken from [Paris Opendata](http://opendata.paris.fr/opendata/jsp/site/Portal.jsp?document_id=60&portlet_id=121)

--- a/docs/8.0/filtering.md
+++ b/docs/8.0/filtering.md
@@ -178,7 +178,7 @@ echo $writer; //the newly added rows are all uppercased
 
 ## Example
 
-Please review <a href="https://github.com/thephpleague/csv/tree/8.x/examples/stream.php" target="_blank">the stream filtering example</a> and the attached <a href="https://github.com/thephpleague/csv/tree/8.x/examples/lib/FilterTranscode.php" target="_blank">FilterTranscode</a> Class to understand how to use the filtering mechanism to convert a CSV into another charset.
+Please review <a href="https://github.com/thephpleague/csv/tree/8.2.3/examples/stream.php" target="_blank">the stream filtering example</a> and the attached <a href="https://github.com/thephpleague/csv/tree/8.2.3/examples/lib/FilterTranscode.php" target="_blank">FilterTranscode</a> Class to understand how to use the filtering mechanism to convert a CSV into another charset.
 
 The `FilterTranscode` class is not attached to the Library because converting your CSV may depend on the extension you choose, in PHP you can use the following extensions :
 

--- a/docs/8.0/index.md
+++ b/docs/8.0/index.md
@@ -125,15 +125,15 @@ foreach ($reader->fetchAssoc(0) as $row) {
 
 ## More Examples
 
-* [Selecting specific rows in the CSV](https://github.com/thephpleague/csv/tree/8.x/examples/extract.php)
-* [Querying a CSV](https://github.com/thephpleague/csv/tree/8.x/examples/filtering.php)
-* [Creating a CSV](https://github.com/thephpleague/csv/tree/8.x/examples/writing.php)
-* [Merging 2 CSV documents](https://github.com/thephpleague/csv/tree/8.x/examples/merge.php)
-* [Switching between modes from Writer to Reader mode](https://github.com/thephpleague/csv/tree/8.x/examples/switchmode.php)
-* [Downloading the CSV](https://github.com/thephpleague/csv/tree/8.x/examples/download.php)
-* [Converting the CSV into a Json String](https://github.com/thephpleague/csv/tree/8.x/examples/json.php)
-* [Converting the CSV into a XML file](https://github.com/thephpleague/csv/tree/8.x/examples/xml.php)
-* [Converting the CSV into a HTML Table](https://github.com/thephpleague/csv/tree/8.x/examples/table.php)
-* [Using stream Filter on the CSV](https://github.com/thephpleague/csv/tree/8.x/examples/stream.php)
+* [Selecting specific rows in the CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/extract.php)
+* [Querying a CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/filtering.php)
+* [Creating a CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/writing.php)
+* [Merging 2 CSV documents](https://github.com/thephpleague/csv/tree/8.2.3/examples/merge.php)
+* [Switching between modes from Writer to Reader mode](https://github.com/thephpleague/csv/tree/8.2.3/examples/switchmode.php)
+* [Downloading the CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/download.php)
+* [Converting the CSV into a Json String](https://github.com/thephpleague/csv/tree/8.2.3/examples/json.php)
+* [Converting the CSV into a XML file](https://github.com/thephpleague/csv/tree/8.2.3/examples/xml.php)
+* [Converting the CSV into a HTML Table](https://github.com/thephpleague/csv/tree/8.2.3/examples/table.php)
+* [Using stream Filter on the CSV](https://github.com/thephpleague/csv/tree/8.2.3/examples/stream.php)
 
 > The CSV data use for the examples are taken from [Paris Opendata](//opendata.paris.fr/opendata/jsp/site/Portal.jsp?document_id=60&portlet_id=121)


### PR DESCRIPTION
The 8.x URLs do not work anymore.

Does not work:
`* [Merging 2 CSV documents](https://github.com/thephpleague/csv/tree/8.x/examples/merge.php)`

Work:
`[Merging 2 CSV documents](https://github.com/thephpleague/csv/tree/8.2.3/examples/merge.php)`

Fixes URLs here https://csv.thephpleague.com/8.0/examples/