### PR TITLE
Improve PHPUnit assertion and fixtures

### DIFF
--- a/src/AbstractCsvTest.php
+++ b/src/AbstractCsvTest.php
@@ -42,7 +42,7 @@ final class AbstractCsvTest extends TestCase
         ['jane', 'doe', 'jane.doe@example.com'],
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $tmp = new SplTempFileObject();
         foreach ($this->expected as $row) {
@@ -52,7 +52,7 @@ final class AbstractCsvTest extends TestCase
         $this->csv = Reader::createFromFileObject($tmp);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->csv);
         @unlink(__DIR__.'/../test_files/newline.csv');

--- a/src/ColumnConsistencyTest.php
+++ b/src/ColumnConsistencyTest.php
@@ -24,12 +24,12 @@ final class ColumnConsistencyTest extends TestCase
     /** @var Writer  */
     private $csv;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->csv = Writer::createFromFileObject(new SplTempFileObject());
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $csv = new SplFileObject(__DIR__.'/../test_files/foo.csv', 'w');
         $csv->setCsvControl();

--- a/src/ReaderTest.php
+++ b/src/ReaderTest.php
@@ -19,7 +19,6 @@ use function count;
 use function fclose;
 use function fopen;
 use function fputcsv;
-use function in_array;
 use function iterator_to_array;
 use function json_encode;
 use function unlink;
@@ -39,7 +38,7 @@ final class ReaderTest extends TestCase
         ['jane', 'doe', 'jane.doe@example.com'],
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $tmp = new SplTempFileObject();
         foreach ($this->expected as $row) {
@@ -49,7 +48,7 @@ final class ReaderTest extends TestCase
         $this->csv = Reader::createFromFileObject($tmp);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->csv);
     }
@@ -124,7 +123,7 @@ EOF;
 
         $this->csv->setHeaderOffset(null);
         foreach ($this->csv->getRecords() as $record) {
-            self::assertTrue(in_array(count($record), [3, 4], true));
+            self::assertContains(count($record), [3, 4]);
         }
     }
 

--- a/src/ResultSetTest.php
+++ b/src/ResultSetTest.php
@@ -48,7 +48,7 @@ final class ResultSetTest extends TestCase
         ['jane', 'doe', 'jane.doe@example.com'],
     ];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $tmp = new SplTempFileObject();
         foreach ($this->expected as $row) {
@@ -59,7 +59,7 @@ final class ResultSetTest extends TestCase
         $this->stmt = Statement::create();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         unset($this->csv, $this->stmt);
     }

--- a/src/StreamTest.php
+++ b/src/StreamTest.php
@@ -37,12 +37,12 @@ use const STREAM_FILTER_READ;
  */
 final class StreamTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         stream_wrapper_register(StreamWrapper::PROTOCOL, StreamWrapper::class);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         stream_wrapper_unregister(StreamWrapper::PROTOCOL);
     }

--- a/src/WriterTest.php
+++ b/src/WriterTest.php
@@ -30,12 +30,12 @@ final class WriterTest extends TestCase
     /** @var Writer */
     private $csv;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->csv = Writer::createFromFileObject(new SplTempFileObject());
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $csv = new SplFileObject(__DIR__.'/../test_files/foo.csv', 'w');
         $csv->setCsvControl();


### PR DESCRIPTION
# Changed log

- Using the `assertContains` to assert expected contains the specific  key.
- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp` and `protected function tearDown` methods.