### PR TITLE
Fix PHP 8.1 deprecation errors

### DIFF
--- a/src/MapIterator.php
+++ b/src/MapIterator.php
@@ -42,6 +42,7 @@ final class MapIterator extends IteratorIterator
     /**
      * @return mixed The value of the current element.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return ($this->callable)(parent::current(), parent::key());

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -321,6 +321,7 @@ final class Stream implements SeekableIterator
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->offset;
@@ -365,6 +366,7 @@ final class Stream implements SeekableIterator
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         if (0 !== ($this->flags & SplFileObject::READ_AHEAD)) {
@@ -381,6 +383,7 @@ final class Stream implements SeekableIterator
      *
      * @return mixed The value of the current element.
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if (false !== $this->value) {


### PR DESCRIPTION
Fixes following errors found running a test suite on PHP 8.1 RC3.

Adding the `#[\ReturnTypeWillChange]` attribute is the only way to prevent these warnings on `current()` methods without breaking compatibility with PHP < 8.0.
For `key()` and `valid()` methods, we could add the return type instead of adding this attribute. I did not do it to prevent issues in inheritance chain, but then I saw these classes are final, so it could be a good solution too. Let me know if you want me to change this.

```
==> Error E_DEPRECATED in ./vendor/league/csv/src/Stream.php on line 384:
Return type of League\Csv\Stream::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in ./vendor/league/csv/src/Stream.php on line 324:
Return type of League\Csv\Stream::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in ./vendor/league/csv/src/Stream.php on line 368:
Return type of League\Csv\Stream::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
==> Error E_DEPRECATED in ./vendor/league/csv/src/MapIterator.php on line 45:
Return type of League\Csv\MapIterator::current() should either be compatible with IteratorIterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```