### PR TITLE
Fix `docs/8.0/` markdownlint errors

### DIFF
--- a/docs/8.0/basic-usage.md
+++ b/docs/8.0/basic-usage.md
@@ -15,16 +15,12 @@ Once your CSV object is [instantiated](/8.0/instantiation) and [configured](/8.0
 The CSV object implements PHP's `IteratorAggregate` interface
 
 ```php
-<?php
-
 public AbstractCsv::getIterator(void): Iterator
 ```
 
 You can iterate over your CSV object to extract each CSV row using the `foreach` construct.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -44,8 +40,6 @@ foreach ($reader as $index => $row) {
 Returns the string representation of the CSV document
 
 ```php
-<?php
-
 public AbstractCsv::__toString(void): string
 ```
 
@@ -54,8 +48,6 @@ Use the `echo` construct on the instantiated object or use the `__toString` meth
 #### Example
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -69,8 +61,6 @@ echo $reader->__toString();
 If you only wish to make your CSV downloadable by forcing a file download just use the `output` method to force the use of the output buffer on the CSV content.
 
 ```php
-<?php
-
 public AbstractCsv::output(string $filename = null): int
 ```
 
@@ -81,8 +71,6 @@ can even remove more headers.
 #### Example 1 - default usage
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 header('Content-Type: text/csv; charset=UTF-8');
@@ -96,8 +84,6 @@ die;
 #### Example 2 - using the $filename argument
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -111,8 +97,6 @@ To avoid breaking the flow of your application, you should create a Response obj
 In some cases you can also use a Streaming Response for larger files.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');

--- a/docs/8.0/bom.md
+++ b/docs/8.0/bom.md
@@ -23,14 +23,10 @@ They each represent the `BOM` character for each encoding character.
 This method will detect and return the `BOM` character used in your CSV if any.
 
 ```php
-<?php
-
 public AbstractCsv::getInputBOM(void): string
 ```
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = new Reader::createFromPath('/path/to/your/file.csv', 'r');
@@ -54,8 +50,6 @@ This method will manage the addition of a BOM character in front of your outputt
 - ouputting the CSV directly using the `__toString()` method
 
 ```php
-<?php
-
 public AbstractCsv::setOutputBOM(string $sequence): AbstractCsv
 ```
 
@@ -68,16 +62,12 @@ public AbstractCsv::setOutputBOM(string $sequence): AbstractCsv
 This method will tell you at any given time what `BOM` character will be prepended to the CSV content.
 
 ```php
-<?php
-
 public AbstractCsv::getOutputBOM(void): string
 ```
 
 <p class="message-warning"><strong>BC Break:</strong> by default <code>getOutputBOM</code> returns an empty string.</p>
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = new Reader::createFromPath('/path/to/your/file.csv', 'r');
@@ -100,8 +90,6 @@ In the examples below we will be using an existing CSV as a starting point. The 
 On Windows, MS Excel, expects an UTF-8 encoded CSV with its corresponding `BOM` character. To fulfill this requirement, you simply need to add the `UTF-8` `BOM` character if needed as explained below:
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -115,8 +103,6 @@ echo $reader->__toString();
 On a MacOS system, MS Excel requires a CSV encoded in `UTF-16 LE` using the `tab` character as delimiter. Here's an example on how to meet those requirements using the `League\Csv` package.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 use League\Csv\Writer;
 use lib\FilterTranscode;

--- a/docs/8.0/converting.md
+++ b/docs/8.0/converting.md
@@ -17,8 +17,6 @@ If your CSV is not UTF-8 encoded some unexpected results and some errors may be 
 `AbstractCsv` implements the `JsonSerializable` interface. As such you can use the `json_encode` function directly on the instantiated object.
 
 ```php
-<?php
-
 echo json_encode($reader);
 ```
 
@@ -27,8 +25,6 @@ echo json_encode($reader);
 Use the `toXML` method to convert the CSV data into a `DomDocument` object.
 
 ```php
-<?php
-
 public AbstractCsv::toXML(
     string $root_name = 'csv',
     string $row_name = 'row',
@@ -43,8 +39,6 @@ This method accepts 3 optionals arguments to help you customize the XML tree:
 - `$cell_name`, the XML node element for each CSV cell which defaults value is `cell`;
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -56,8 +50,6 @@ $dom = $reader->toXML('data', 'line', 'item');
 Use the `toHTML` method to convert the CSV data into an HTML table.
 
 ```php
-<?php
-
 public AbstractCsv::toHTML(string $classAttribute = 'table-csv-data'): string
 ```
 
@@ -65,8 +57,6 @@ This method accepts an optional argument `$classAttribute` to help you customize
 rendering. By default, the classname given to the table is `table-csv-data`.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -76,8 +66,6 @@ echo $reader->toHTML('table table-bordered table-hover');
 ## Example using data transcode before conversion
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromFileObject(new SplFileObject('/path/to/bengali.csv'));

--- a/docs/8.0/examples.md
+++ b/docs/8.0/examples.md
@@ -11,8 +11,6 @@ redirect_from: /examples/
 A simple example to show you how to parse a CSV document.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
@@ -29,8 +27,6 @@ $res = $csv->setOffset(10)->setLimit(25)->fetchAll();
 A simple example to show you how to create and download a CSV from a `PDOStatement` object
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 //we fetch the info from a DB using a PDO object
@@ -66,8 +62,6 @@ die;
 A simple example to show you how to import some CSV data into a database using a `PDOStatement` object
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 //We are going to insert some data into the users table
@@ -93,8 +87,6 @@ When importing csv files, you don't know whether the file is encoded with `UTF-8
 The below example tries to determine the encoding and convert to `UTF-8` using the iconv extension.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');

--- a/docs/8.0/filtering.md
+++ b/docs/8.0/filtering.md
@@ -23,16 +23,12 @@ To be able to use the stream filtering mechanism you need to:
 To be sure that the Stream Filter API is available it is recommend to use the method `isActiveStreamFilter`.
 
 ```php
-<?php
-
 public AbstractCsv::isActiveStreamFilter(void): bool
 ```
 
 `isActiveStreamFilter` returns `true` if you can safely use the API:
 
 ```php
-<?php
-
 use League\Csv\Reader;
 use League\Csv\Writer;
 
@@ -50,8 +46,6 @@ $writer->isActiveStreamFilter(); //return false the API can not be use
 The stream filter mode property is set using PHP internal stream filter constant `STREAM_FILTER_*`.
 
 ```php
-<?php
-
 public AbstractCsv::setStreamFilterMode(int $mode): AbstractCsv
 public AbstractCsv::getStreamFilterMode(void): int
 ```
@@ -68,8 +62,6 @@ By default:
 - If you instantiate the class using a PHP filter meta wrapper (ie: `php://filter/`), the mode will be the one used by the meta wrapper;
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -87,8 +79,6 @@ if ($reader->isActiveStreamFilter()) {
 To manage your registered stream filter collection you can use the following methods:
 
 ```php
-<?php
-
 public AbstractCsv::appendStreamFilter(string $filtername): AbstractCsv
 public AbstractCsv::prependStreamFilter(string $filtername): AbstractCsv
 public AbstractCsv::removeStreamFilter(string $filtername): AbstractCsv
@@ -114,8 +104,6 @@ The filters are automatically applied when the stream filter mode matches the me
 See below an example using `League\Csv\Reader` to illustrate:
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 stream_filter_register('convert.utf8decode', 'MyLib\Transcode');
@@ -137,8 +125,6 @@ foreach ($reader as $row) {
 <p class="message-notice">Starting with version <code>8.1.0</code> you no longer need to URL encode your filter prior to attach it to the CSV object.</p>
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/chinese.csv', 'r');
@@ -153,8 +139,6 @@ var_dump($reader->fetchAll());
 <p class="message-warning"><strong>Warning:</strong> To preserve file cursor position during editing the stream filter mode and the stream filter collection are frozen after the first insert is made using any of the <code>insert*</code> method. Any attempt to modify the stream filter status will fail silently.</p>
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $writer = Writer::createFromPath('/path/to/my/file.csv');

--- a/docs/8.0/index.md
+++ b/docs/8.0/index.md
@@ -24,8 +24,6 @@ by utilizing PHP native classes whenever possible.
 A simple example to show you how to parse a CSV document.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
@@ -42,8 +40,6 @@ $res = $csv->setOffset(10)->setLimit(25)->fetchAll();
 A simple example to show you how to create and download a CSV from a `PDOStatement` object
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 //we fetch the info from a DB using a PDO object
@@ -79,8 +75,6 @@ die;
 A simple example to show you how to import some CSV data into a database using a `PDOStatement` object
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 //We are going to insert some data into the users table
@@ -106,8 +100,6 @@ When importing csv files, you don't know whether the file is encoded with `UTF-8
 The below example tries to determine the encoding and convert to `UTF-8` using the iconv extension.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');

--- a/docs/8.0/inserting.md
+++ b/docs/8.0/inserting.md
@@ -29,8 +29,6 @@ To add new data to your CSV the `Writer` class uses the following methods
 `insertOne` inserts a single row.
 
 ```php
-<?php
-
 public Writer::insertOne(mixed $row): Writer
 ```
 
@@ -43,8 +41,6 @@ This method takes a single argument `$row` which can be
 #### Example
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 class ToStringEnabledClass
@@ -75,8 +71,6 @@ In the above example, all the CSV records are saved to the `/path/to/saved/file.
 `insertAll` inserts multiple rows.
 
 ```php
-<?php
-
 public Writer::insertAll(mixed $rows): Writer
 ```
 
@@ -90,8 +84,6 @@ to add several rows to the CSV data.
 #### Example
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $rows = [
@@ -113,8 +105,6 @@ $writer->insertAll(new ArrayIterator($rows)); //using a Traversable object
 A formatter is a `callable` which accepts an `array` on input and returns the same array formatted according to its inner rules.
 
 ```php
-<?php
-
 function(array $row): array
 ```
 
@@ -125,8 +115,6 @@ You can attach as many formatters as you want to the `Writer` class to manipulat
 The formatter API comes with the following public API:
 
 ```php
-<?php
-
 public Writer::addFormatter(callable $callable): Writer
 public Writer::removeFormatter(callable $callable): Writer
 public Writer::hasFormatter(callable $callable): bool
@@ -139,8 +127,6 @@ public Writer::clearFormatters(void): Writer
 - `clearFormatters`: removes all registered formatters.
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $formatter = function ($row) {
@@ -161,8 +147,6 @@ $writer->__toString();
 A validator is a `callable` which takes a `array` as its sole argument and returns a boolean.
 
 ```php
-<?php
-
 function(array $row): bool
 ```
 
@@ -177,8 +161,6 @@ As with the new formatter capabilities, you can attach as many validators as you
 The validator API comes with the following public API:
 
 ```php
-<?php
-
 public Writer::addValidator(callable $callable, string $validatorName): Writer
 public Writer::removeValidator(string $validatorName): Writer
 public Writer::hasValidator(string $validatorName): bool
@@ -198,8 +180,6 @@ If the validation failed a `League\Csv\Exception\InvalidRowException` is thrown 
 This exception extends PHP's `InvalidArgumentException` by adding two public getter methods
 
 ```php
-<?php
-
 public InvalidRowException::getName(void): string
 public InvalidRowException::getData(void): array
 ```
@@ -210,8 +190,6 @@ public InvalidRowException::getData(void): array
 #### Validation example
 
 ```php
-<?php
-
 use League\Csv\Writer;
 use League\Csv\Exception\InvalidRowException;
 
@@ -233,8 +211,6 @@ try {
 The `League\Csv\Plugin\ForbiddenNullValuesValidator` class validates the absence of `null` values
 
 ```php
-<?php
-
 use League\Csv\Writer;
 use League\Csv\Plugin\ForbiddenNullValuesValidator;
 
@@ -250,8 +226,6 @@ $writer->insertOne(["foo", null, "bar"]);
 The `League\Csv\Plugin\SkipNullValuesFormatter` class skips cell using founded `null` values
 
 ```php
-<?php
-
 use League\Csv\Writer;
 use League\Csv\Plugin\SkipNullValuesFormatter;
 
@@ -268,8 +242,6 @@ $writer->insertOne(["foo", null, "bar"]);
 The `League\Csv\Plugin\ColumnConsistencyValidator` class validates the inserted record column count consistency.
 
 ```php
-<?php
-
 use League\Csv\Writer;
 use League\Csv\Plugin\ColumnConsistencyValidator;
 
@@ -295,8 +267,6 @@ Because the php `fputcsv` implementation has a hardcoded `\n`, we need to be abl
 At any given time you can get and modify the `$newline` property using the `getNewline` and `setNewline` methods described in <a href="/8.0/properties/">CSV properties documentation page</a>.
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $writer = Writer::createFromFileObject(new SplFileObject());

--- a/docs/8.0/installation.md
+++ b/docs/8.0/installation.md
@@ -31,8 +31,6 @@ The library is compatible with any [PSR-4](http://www.php-fig.org/psr/psr-4/) co
 Also, `League\Csv` comes bundle with its own autoloader script `autoload.php` located in the root directory.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 use League\Csv\Writer;
 

--- a/docs/8.0/instantiation.md
+++ b/docs/8.0/instantiation.md
@@ -18,8 +18,6 @@ Both classes extend the `League\Csv\AbstractCsv` class and as such share methods
 If your CSV document was created or is read on a Macintosh computer, add the following lines before using the library to help [PHP detect line ending in Mac OS X](http://php.net/manual/en/function.fgetcsv.php#refsect1-function.fgetcsv-returnvalues).
 
 ```php
-<?php
-
 if (!ini_get("auto_detect_line_endings")) {
     ini_set("auto_detect_line_endings", '1');
 }
@@ -36,8 +34,6 @@ Because CSVs come in different forms we used named constructors to offer several
 This named constructor will create a new object *à la* `fopen`.
 
 ```php
-<?php
-
 public static AbstractCsv::createFromPath(
     mixed $path,
     string $open_mode = 'r+'
@@ -55,8 +51,6 @@ public static AbstractCsv::createFromPath(
 The resulting string and `$open_mode` parameters are used to lazy load internally a `SplFileObject` object.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 use League\Csv\Writer;
 
@@ -71,16 +65,12 @@ $writer = Writer::createFromPath(new SplFileObject('/path/to/your/csv/file.csv',
 Instantiate a new Csv object from a `SplFileObject`.
 
 ```php
-<?php
-
 public static AbstractCsv::createFromFileObject(SplFileObject $obj): AbstractCsv
 ```
 
 This method accepts only one single parameter, a `SplFileObject` object.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 use League\Csv\Writer;
 
@@ -93,16 +83,12 @@ $writer = Writer::createFromFileObject(new SplTempFileObject());
 This named constructor will create a new object from a given string.
 
 ```php
-<?php
-
 public static AbstractCsv::createFromString(mixed $str): AbstractCsv
 ```
 
 This method accepts only one single parameter, an object implementing the `__toString` method or a string.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 use League\Csv\Writer;
 
@@ -117,16 +103,12 @@ $writer = Writer::createFromString('john,doe,john.doe@example.com');
 This named constructor will create a new object from a stream resource.
 
 ```php
-<?php
-
 public static AbstractCsv::createFromStream(resource $stream): AbstractCsv
 ```
 
 This method accepts only one single parameter, a resource stream. The resource stream <strong>MUST</strong> be seekable otherwise a `InvalidArgumentException` will be thrown.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 use League\Csv\Writer;
 
@@ -144,8 +126,6 @@ At any given time you can switch or create a new `League\Csv\Writer` or a new `L
 Both methods accept an optional `$open_mode` parameter.
 
 ```php
-<?php
-
 public AbstractCsv::newReader(string $open_mode = 'r+'): Reader
 public AbstractCsv::newWriter(string $open_mode = 'r+'): Writer
 ```
@@ -154,8 +134,6 @@ public AbstractCsv::newWriter(string $open_mode = 'r+'): Writer
 - If the initial object `$open_mode` parameter was not taken into account any new CSV object created with these methods won't take into account the given `$open_mode`.
 
 ```php
-<?php
-
 $reader = $writer->newReader('r+');
 $newWriter = $reader->newWriter('a');
 $anotherWriter = $newWriter->newWriter('r+');

--- a/docs/8.0/properties.md
+++ b/docs/8.0/properties.md
@@ -11,8 +11,6 @@ Once your object is [instantiated](/8.0/instantiation/) you can optionally set s
 <p class="message-notice">Since <code>version 8.1.1</code> The underlying CSV controls from the submitted CSV are inherited by the return <code>AbstractCsv</code> object.</p>
 
 ```php
-<?php
-
 $file = new SplTempFileObject();
 $file->setFlags(SplFileObject::READ_CSV);
 $file->setCsvControl('|');
@@ -31,8 +29,6 @@ echo $csv->getDelimiter(); //display '|'
 #### Description
 
 ```php
-<?php
-
 public AbstractCsv::setDelimiter(string $delimiter): AbstractCsv
 public AbstractCsv::getDelimiter(void): string
 ```
@@ -40,8 +36,6 @@ public AbstractCsv::getDelimiter(void): string
 #### Example
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -58,8 +52,6 @@ The default delimiter character is `,`.
 #### Description
 
 ```php
-<?php
-
 public AbstractCsv::setEnclosure(string $delimiter): AbstractCsv
 public AbstractCsv::getEnclosure(void): string
 ```
@@ -67,8 +59,6 @@ public AbstractCsv::getEnclosure(void): string
 #### Example
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $csv = Writer::createFromPath('/path/to/file.csv');
@@ -88,8 +78,6 @@ A possible workaround to this issue while waiting for a PHP bug fix is <a href="
 #### Description
 
 ```php
-<?php
-
 public AbstractCsv::setEscape(string $delimiter): AbstractCsv
 public AbstractCsv::getEscape(void): string
 ```
@@ -97,8 +85,6 @@ public AbstractCsv::getEscape(void): string
 #### Example
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -115,8 +101,6 @@ The default escape character is `\`.
 This method allow you to find the occurrences of some delimiters in a given CSV object.
 
 ```php
-<?php
-
 public AbstractCsv::fetchDelimitersOccurrence(
     array $delimiters,
     int $nbRows = 1
@@ -129,8 +113,6 @@ The method takes two arguments:
 - an integer which represents the number of rows to scan (default to `1`);
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
@@ -163,8 +145,6 @@ To improve interoperability with programs interacting with CSV, the newline sequ
 #### Description
 
 ```php
-<?php
-
 public AbstractCsv::setNewline(string $sequence): AbstractCsv
 public AbstractCsv::getNewline(void): string
 ```
@@ -172,8 +152,6 @@ public AbstractCsv::getNewline(void): string
 #### Example
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $csv = Writer::createFromPath('/path/to/file.csv');
@@ -194,16 +172,12 @@ To improve interoperability with programs interacting with CSV, you can manage t
 <p class="message-warning"><strong>BC Break:</strong> <code>getInputBOM</code> always return a string</p>
 
 ```php
-<?php
-
 public AbstractCsv::getInputBOM(void): string
 ```
 
 Detect the current BOM character is done using the `getInputBOM` method. This method returns the currently used BOM character or an empty string if none is found or recognized.
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $csv = Writer::createFromPath('/path/to/file.csv');
@@ -213,8 +187,6 @@ $bom = $csv->getInputBOM();
 #### Set the outputting BOM sequence
 
 ```php
-<?php
-
 public AbstractCsv::setOutputBOM(string $sequence): AbstractCsv
 public AbstractCsv::getOutputBOM(void): string
 ```
@@ -225,8 +197,6 @@ public AbstractCsv::getOutputBOM(void): string
 <p class="message-warning"><strong>BC Break:</strong> <code>getOutputBOM</code> always return a string</p>
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -254,8 +224,6 @@ When this is not the case, you should transcode it first using the <a href="/8.0
 <p class="message-notice">These methods are introduced in version <code>8.1.0</code></p>
 
 ```php
-<?php
-
 public AbstractCsv::setInputEncoding(string $sequence): AbstractCsv
 public AbstractCsv::getInputEncoding(void): string
 ```
@@ -263,8 +231,6 @@ public AbstractCsv::getInputEncoding(void): string
 <p class="message-warning">The following methods are deprecated since version <code>8.1.0</code> and will be remove in the next major release</p>
 
 ```php
-<?php
-
 public AbstractCsv::setEncodingFrom(string $sequence): AbstractCsv
 public AbstractCsv::getEncodingFrom(void): string
 ```
@@ -275,8 +241,6 @@ public AbstractCsv::getEncodingFrom(void): string
 #### Example
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -291,8 +255,6 @@ By default `getInputEncoding` returns `UTF-8` if `setInputEncoding` was not used
 <div class="message-warning">The encoding properties have no effect when reading or writing to a CSV document. You should instead use <a href="/8.0/filtering/">the Stream Filter API</a> or <a href="/8.0/inserting/#row-formatting">the Writing Formatter API</a>.</div>
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromFileObject(new SplFileObject('/path/to/bengali.csv'));

--- a/docs/8.0/query-filtering.md
+++ b/docs/8.0/query-filtering.md
@@ -21,8 +21,6 @@ You can restrict [extract methods](/8.0/reading/) and [conversion methods](/8.0/
 This method specifies if the [BOM sequence](/bom/) must be removed or not from the CSV's first cell of the first row.
 
 ```php
-<?php
-
 public AbstractCsv::stripBOM(bool $status): AbstractCsv
 ```
 
@@ -41,16 +39,12 @@ The filtering options **are the first settings applied to the CSV before anythin
 The `addFilter` method adds a callable filter function each time it is called.
 
 ```php
-<?php
-
 public AbstractCsv::addFilter(callable $callable): AbstractCsv
 ```
 
 The callable filter signature is as follows:
 
 ```php
-<?php
-
 function(array $row [, int $rowOffset [, Iterator $iterator]]): AbstractCsv
 ```
 
@@ -72,16 +66,12 @@ The sorting options are applied **after the CSV filtering options**. The sorting
 `addSortBy` method adds a sorting function each time it is called.
 
 ```php
-<?php
-
 public AbstractCsv::addSortBy(callable $callable): AbstractCsv
 ```
 
 The callable sort function signature is as follows:
 
 ```php
-<?php
-
 function(array $row, array $row): int
 ```
 
@@ -94,8 +84,6 @@ The interval methods enable returning a specific interval of CSV rows. When call
 The interval API is made of the following method
 
 ```php
-<?php
-
 public AbstractCsv::setOffset(int $offset = 0): AbstractCsv
 public AbstractCsv::setLimit(int $limit = -1): AbstractCsv
 ```
@@ -114,8 +102,6 @@ Where
 Here's an example on how to use the query features of the `Reader` class to restrict the `fetchAssoc` result:
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 function filterByEmail($row)
@@ -153,8 +139,6 @@ $data = $reader
 The query options can also modify the output from the conversion methods as shown below with the `toHTML` method.
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 function filterByEmail($row)

--- a/docs/8.0/reading.md
+++ b/docs/8.0/reading.md
@@ -19,16 +19,12 @@ strongly suggested to set <code>r</code> mode on the file to ensure it can be op
 The `fetch` method fetches the next row from the `Iterator` result set.
 
 ```php
-<?php
-
 public Reader::fetch(callable $callable = null): Iterator
 ```
 
 The method takes an optional callable parameter to apply to each row of the resultset before returning. The callable signature is as follow:
 
 ```php
-<?php
-
 function(array $row [, int $rowOffset [, Iterator $iterator]]): array
 ```
 
@@ -39,8 +35,6 @@ function(array $row [, int $rowOffset [, Iterator $iterator]]): array
 ### Example 1
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -53,8 +47,6 @@ foreach ($results as $row) {
 ### Example 2 - with a callable
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $func = function ($row) {
@@ -73,8 +65,6 @@ foreach ($results as $row) {
 `fetchAll` returns a sequential `array` of all rows.
 
 ```php
-<?php
-
 public Reader::fetchAll(callable $callable = null): array
 ```
 
@@ -87,8 +77,6 @@ public Reader::fetchAll(callable $callable = null): array
 `fetchOne` return one single row from the CSV data as an `array`.
 
 ```php
-<?php
-
 public Reader::fetchOne($offset = 0): array
 ```
 
@@ -97,8 +85,6 @@ The required argument `$offset` represents the row index starting at `0`. If no 
 ### Example
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -114,8 +100,6 @@ $data = $reader->fetchOne(3); ///accessing the 4th row (indexing starts at 0)
 `each` applies a callable function on each CSV row.
 
 ```php
-<?php
-
 public Reader::each(callable $callable): int
 ```
 
@@ -124,8 +108,6 @@ The method returns the number of successful iterations.
 The callable signature is as follows:
 
 ```php
-<?php
-
 function(array $row [, int $rowOffset [, Iterator $iterator]]): bool
 ```
 
@@ -138,8 +120,6 @@ The callable must return `true` to continue iterating over the CSV;
 ### Example - Counting the CSV total number of rows
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -157,8 +137,6 @@ $nbRows = $reader->each(function ($row) {
 `fetchAssoc` returns an `Iterator` of all rows. The rows themselves are associative arrays where the keys are a one dimension array. This array must only contain unique `string` and/or `scalar` values.
 
 ```php
-<?php
-
 public Reader::fetchAssoc(
     mixed $offset_or_keys = 0,
     callable $callable = null
@@ -173,8 +151,6 @@ This `$offset_or_keys` argument can be
 ### Example 1 - Using an array to specify the keys
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -195,8 +171,6 @@ foreach ($results as $row) {
 ### Example 2 - Using a CSV offset
 
 ```php
-<?php
-
 $offset = 0;
 $results = $reader->fetchAssoc($offset);
 // $results is an iterator
@@ -235,8 +209,6 @@ function(array $row [, int $rowOffset [, Iterator $iterator]]): array
 ### Example 3 - Using a callable
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $func = function ($row) {
@@ -259,8 +231,6 @@ foreach ($reader->fetchAssoc($keys, $func) as $row) {
 `fetchColumn` returns a `Iterator` of all values in a given column from the CSV data.
 
 ```php
-<?php
-
 public Reader::fetchColumn(
     int $columnIndex = 0,
     callable $callable = null
@@ -272,8 +242,6 @@ If for a given row the column does not exist, the row will be skipped.
 ### Example 1 - with a given column index
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -292,8 +260,6 @@ $data = iterator_to_array($result, false);
 The method takes an optional callable which signature is as follow:
 
 ```php
-<?php
-
 function(string $value [, int $offsetIndex [, Iterator $iterator]]): mixed
 ```
 
@@ -304,8 +270,6 @@ function(string $value [, int $offsetIndex [, Iterator $iterator]]): mixed
 ### Example 2 - with a callable
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -321,8 +285,6 @@ foreach ($reader->fetchColumn(2, 'strtoupper') as $value) {
 The `fetchPairs` method returns a `Generator` of key-value pairs.
 
 ```php
-<?php
-
 public Reader::fetchPairs(
     int $offsetIndex = 0,
     int $valueIndex = 1,
@@ -336,8 +298,6 @@ public Reader::fetchPairs(
 ### Example 1 - default usage
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $str = <<EOF
@@ -372,8 +332,6 @@ foreach ($reader->fetchPairs() as $firstname => $lastname) {
 The method takes an optional callable which signature is as follow:
 
 ```php
-<?php
-
 function(array $pairs [, int $rowOffset [, Iterator $iterator]]): array
 ```
 
@@ -386,8 +344,6 @@ function(array $pairs [, int $rowOffset [, Iterator $iterator]]): array
 ### Example 2 - with a callable
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $str = <<EOF
@@ -423,8 +379,6 @@ foreach ($reader->fetchPairs(1, 0, $func) as $lastname => $firstname) {
 The `fetchPairsWithoutDuplicates` method returns data in an `array` of key-value pairs, as an associative array with a single entry per row.
 
 ```php
-<?php
-
 public Reader::fetchPairsWithoutDuplicates(
     int $offsetIndex = 0,
     int $valueIndex = 1,
@@ -438,8 +392,6 @@ public Reader::fetchPairsWithoutDuplicates(
 - When using `fetchPairsWithoutDuplicates` entries in the associative array will be overwritten if there are duplicates values in the column index.
 
 ```php
-<?php
-
 $str = <<EOF
 john,doe
 jane,doe

--- a/docs/8.0/upgrading.md
+++ b/docs/8.0/upgrading.md
@@ -40,8 +40,6 @@ In version 8.0 the optional second argument from `createFromString` is removed. 
 **Old code:**
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $writer = Writer::createFromString($str, "\r\n");
@@ -51,8 +49,6 @@ $writer->insertOne(["foo", null, "bar"]);
 **New code:**
 
 ```php
-<?php
-
 use League\Csv\Writer;
 
 $writer = Writer::createFromString($str);
@@ -72,8 +68,6 @@ The `SplFileObject` flags are normalized to have a normalized CSV filtering inde
 **Old code:**
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -84,8 +78,6 @@ $csv->fetchAssoc(); //empty lines where removed
 **New code:**
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -99,8 +91,6 @@ $csv->fetchAssoc(); //empty lines are automatically removed
 **Old code:**
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -112,8 +102,6 @@ echo $res[0]['lastname']; //would return the first row 'lastname' index
 **New code:**
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
@@ -129,8 +117,6 @@ The optional callable argument from `Reader::fetchAssoc` now expects its first a
 **Old code:**
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $func = function (array $row) {
@@ -147,8 +133,6 @@ $res = $csv->fetchAssoc(['lastname', 'firstname'], $func);
 **New code:**
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $func = function (array $row) {
@@ -169,8 +153,6 @@ The optional callable argument from `Reader::fetchColumn` now expects its first 
 **Old code:**
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $func = function (array $row) {
@@ -186,8 +168,6 @@ $res = $csv->fetchColumn(2, $func);
 **New code:**
 
 ```php
-<?php
-
 use League\Csv\Reader;
 
 $func = function ($value) {


### PR DESCRIPTION
Follow up to https://github.com/thephpleague/csv/pull/441#issuecomment-944160708 and https://github.com/thephpleague/csv/pull/442, this fixes the markdownlint violations in `docs/8.0/`.