### PR TITLE
Add Lint Docs GitHub Action

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: github/super-linter@v3
+      - uses: github/super-linter/slim@v4
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds running `markdownlint` on pushes/PRs to ensure markdown is consistent across contributors.

An example failure can be seen here (errors already resolved in previous PRs): https://github.com/pdelre/csv/runs/3908903455?check_suite_focus=true

![image](https://user-images.githubusercontent.com/1379248/137541679-e11e4d5d-64e0-43ce-b9b4-8041897a7f66.png)
