### PR TITLE
Adding new fetchColumn* method and deprecate the current method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All Notable changes to `Csv` will be documented in this file
 ### Added
 
 - Added PHP7.4 typed properties where applicable
+- `TabularDataReader::fetchColumnByName` to replace the namespace function `TabularDataReader::fetchColumn`
+- `TabularDataReader::fetchColumnByOffset` to replace the namespace function `TabularDataReader::fetchColumn`
 
 ### Deprecated
 
-- None
+- `TabularDataReader::fetchColumn` use `TabularDataReader::fetchColumnByOffset` or `TabularDataReader::fetchColumnByName` instead
 
 ### Fixed
 

--- a/docs/9.0/reader/index.md
+++ b/docs/9.0/reader/index.md
@@ -8,10 +8,9 @@ title: CSV document Reader connection
 The `League\Csv\Reader` class extends the general connections [capabilities](/9.0/connections/) to ease selecting and manipulating CSV document records.
 
 <p class="message-notice">Starting with version <code>9.1.0</code>, <code>createFromPath</code> when used from the <code>Reader</code> object will have its default set to <code>r</code>.</p>
-
 <p class="message-notice">Prior to <code>9.1.0</code>, by default, the mode for a <code>Reader::createFromPath</code> is <code>r+</code> which looks for write permissions on the file and throws an <code>Exception</code> if the file cannot be opened with the permission set. For sake of clarity, it is strongly suggested to set <code>r</code> mode on the file to ensure it can be opened.</p>
-
 <p class="message-info">Starting with version <code>9.6.0</code>, the class implements the <code>League\Csv\TabularDataReader</code> interface.</p>
+<p class="message-info">Starting with version <code>9.8.0</code>, the class implements the <code>::fetchColumnByName</code> and <code>::fetchColumnByOffset</code> methods.</p>
 
 ## CSV example
 
@@ -347,6 +346,8 @@ count($reader); // returns 4
 ### Simple Usage
 
 ```php
+public Reader::fetchColumnByName(string $columnName): Iterator
+public Reader::fetchColumnByIndex(int $columnIndex = 0): Iterator
 public Reader::fetchColumn(string|int $columnIndex = 0): Generator
 public Reader::fetchOne(int $nth_record = 0): array
 public Reader::fetchPairs(string|int $offsetIndex = 0, string|int $valueIndex = 1): Generator
@@ -361,7 +362,7 @@ use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 
-$records = $reader->fetchColumn(2);
+$records = $reader->fetchColumnByOffset(2);
 //$records is a Generator representing all the fields of the CSV 3rd column
 ```
 

--- a/docs/9.0/reader/resultset.md
+++ b/docs/9.0/reader/resultset.md
@@ -221,7 +221,7 @@ count(iterator_to_array($records->fetchColumnByOffset(2), false)); //returns 5
 //5 records were skipped because the column value is null
 ```
 
-<p class="message-warning">The following paragraph describe the usage of the <code>::fetchColumn</code> method which is 
+<p class="message-warning">The following paragraph describe the usage of the <code>::fetchColumn</code> method which is
 deprecated as of <code>9.8.0</code> and which wil be removed in the next major release.</p>
 
 `ResultSet::fetchColumn` returns a `Generator` of all values in a given column from the `ResultSet` object.

--- a/docs/9.0/reader/resultset.md
+++ b/docs/9.0/reader/resultset.md
@@ -8,6 +8,7 @@ title: Accessing Records from a CSV document
 A `League\Csv\ResultSet` object represents the associated result set of processing a [CSV document](/9.0/reader/) with a [constraint builder](/9.0/reader/statement/). This object is returned from [Statement::process](/9.0/reader/statement/#apply-the-constraints-to-a-csv-document) execution.
 
 <p class="message-info">Starting with version <code>9.6.0</code>, the class implements the <code>League\Csv\TabularDataReader</code> interface.</p>
+<p class="message-info">Starting with version <code>9.8.0</code>, the class implements the <code>::fetchColumnByName</code> and <code>::fetchColumnByOffset</code> methods.</p>
 
 ## Informations
 
@@ -151,8 +152,77 @@ $data = $stmt->process($reader)->fetchOne(3);
 ## Selecting a single column
 
 ```php
-public ResultSet::fetchColumn(string|int $columnIndex = 0): Generator
+public ResultSet::fetchColumnByName(string $name): Iterator
+public ResultSet::fetchColumnByOffset(int $offset = 0): Iterator
+public ResultSet::fetchColumn(string|int $columnIndex = 0): Iterator
 ```
+
+Since with version <code>9.8.0</code>, the class implements the `::fetchColumnByName` and `::fetchColumnByOffset` methods.
+These methods replace the `::fetchColumn` which is deprecated and will be removed in the next major release.
+
+Both methods return a `Iterator` of all values in a given column from the `ResultSet` object. But they differ
+in their argument type:
+
+`::fetchColumnByName` expects a string representing one of the value of `ResultSet::getHeader`
+
+```php
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$reader->setHeaderOffset(0);
+$records = Statement::create()->process($reader);
+foreach ($records->fetchColumnByName('E-mail') as $value) {
+    //$value is a string representing the value
+    //of a given record for the selected column
+    //$value may be equal to 'john.doe@example.com'
+}
+```
+
+<p class="message-warning">If the <code>ResultSet</code> contains column names and the <code>$name</code> is not found an <code>Exception</code> exception is thrown.</p>
+
+```php
+use League\Csv\Reader;
+use League\Csv\Statement;
+
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$reader->setHeaderOffset(0);
+
+$records = Statement::create()->process($reader);
+foreach ($records->fetchColumnByName('foobar') as $record) {
+    //throw an Exception exception if
+    //no `foobar` column name is found
+    //in $records->getHeader() result
+}
+```
+
+`::fetchColumnByOffset` expects an integer representing the column index starting from `0`;
+
+```php
+use League\Csv\Reader;
+use League\Csv\Statement;
+
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$records = Statement::create()->process($reader);
+foreach ($records->fetchColumnByOffset(2) as $value) {
+    //$value is a string representing the value
+    //of a given record for the selected column
+    //$value may be equal to 'john.doe@example.com'
+}
+```
+
+<p class="message-notice">For both methods, if for a given record the column value is <code>null</code>, the record will be skipped.</p>
+
+```php
+use League\Csv\Reader;
+use League\Csv\Statement;
+
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$records = Statement::create()->process($reader);
+count($records); //returns 10;
+count(iterator_to_array($records->fetchColumnByOffset(2), false)); //returns 5
+//5 records were skipped because the column value is null
+```
+
+<p class="message-warning">The following paragraph describe the usage of the <code>::fetchColumn</code> method which is 
+deprecated as of <code>9.8.0</code> and which wil be removed in the next major release.</p>
 
 `ResultSet::fetchColumn` returns a `Generator` of all values in a given column from the `ResultSet` object.
 
@@ -183,8 +253,6 @@ foreach ($records->fetchColumn('E-mail') as $value) {
     //$value may be equal to 'john.doe@example.com'
 }
 ```
-
-<p class="message-notice">If for a given record the column value is <code>null</code>, the record will be skipped.</p>
 
 ```php
 use League\Csv\Reader;

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -246,7 +246,7 @@ abstract class AbstractCsv implements ByteSequence
     public function supportsStreamFilterOnRead(): bool
     {
         return $this->document instanceof Stream
-            && ((static::STREAM_FILTER_MODE & STREAM_FILTER_READ) === STREAM_FILTER_READ);
+            && (static::STREAM_FILTER_MODE & STREAM_FILTER_READ) === STREAM_FILTER_READ;
     }
 
     /**
@@ -255,7 +255,7 @@ abstract class AbstractCsv implements ByteSequence
     public function supportsStreamFilterOnWrite(): bool
     {
         return $this->document instanceof Stream
-            && ((static::STREAM_FILTER_MODE & STREAM_FILTER_WRITE) === STREAM_FILTER_WRITE);
+            && (static::STREAM_FILTER_MODE & STREAM_FILTER_WRITE) === STREAM_FILTER_WRITE;
     }
 
     /**

--- a/src/MapIteratorTest.php
+++ b/src/MapIteratorTest.php
@@ -27,9 +27,7 @@ final class MapIteratorTest extends TestCase
     {
         $array = [1, 2, 3, 4, 5];
         $iterator = new ArrayIterator($array);
-        $mapper = function (int $number): int {
-            return ($number * $number * $number);
-        };
+        $mapper = fn (int $number): int => ($number * $number * $number);
 
         self::assertSame(
             array_map($mapper, $array),
@@ -44,9 +42,7 @@ final class MapIteratorTest extends TestCase
             'bar' => 'bar => baz',
         ];
         $iterator = new ArrayIterator(['foo' => 'bar', 'bar' => 'baz']);
-        $mapper = function (string $value, $offset): string {
-            return $offset.' => '.$value;
-        };
+        $mapper = fn (string $value, $offset): string =>  $offset.' => '.$value;
 
         self::assertSame(
             $expected,

--- a/src/ReaderTest.php
+++ b/src/ReaderTest.php
@@ -156,6 +156,8 @@ EOF;
 
     /**
      * @covers ::fetchColumn
+     * @covers ::fetchColumnByName
+     * @covers ::fetchColumnByOffset
      * @covers ::fetchOne
      * @covers ::fetchPairs
      */
@@ -179,6 +181,8 @@ EOF;
         $res = Statement::create()->process($csv);
         self::assertEquals($csv->fetchOne(3), $res->fetchOne(3));
         self::assertEquals($csv->fetchColumn('firstname'), $res->fetchColumn('firstname'));
+        self::assertEquals($csv->fetchColumnByName('firstname'), $res->fetchColumnByName('firstname'));
+        self::assertEquals($csv->fetchColumnByOffset(1), $res->fetchColumnByOffset(1));
         self::assertEquals($csv->fetchPairs('lastname', 0), $res->fetchPairs('lastname', 0));
     }
 

--- a/src/TabularDataReader.php
+++ b/src/TabularDataReader.php
@@ -19,6 +19,9 @@ use IteratorAggregate;
 
 /**
  * Represents a Tabular data.
+ *
+ * @method Iterator fetchColumnByName(string $name)  returns a column from its name
+ * @method Iterator fetchColumnByOffset(int $offset) returns a column from its offset
  */
 interface TabularDataReader extends Countable, IteratorAggregate
 {
@@ -80,6 +83,13 @@ interface TabularDataReader extends Countable, IteratorAggregate
     public function fetchOne(int $nth_record = 0): array;
 
     /**
+     * DEPRECATION WARNING! This class will be removed in the next major point release.
+     *
+     * @deprecated since version 9.8.0
+     *
+     * @see ::fetchColumnByName
+     * @see ::fetchColumnByOffset
+     *
      * Returns a single column from the next record of the tabular data.
      *
      * By default if no value is supplied the first column is fetch

--- a/src/WriterTest.php
+++ b/src/WriterTest.php
@@ -199,22 +199,14 @@ final class WriterTest extends TestCase
 
     public function testAddValidationRules(): void
     {
-        $func = function (array $row): bool {
-            return false;
-        };
-
         $this->expectException(CannotInsertRecord::class);
-        $this->csv->addValidator($func, 'func1');
+        $this->csv->addValidator(fn (array $row): bool => false, 'func1');
         $this->csv->insertOne(['jane', 'doe']);
     }
 
     public function testFormatterRules(): void
     {
-        $func = function (array $row): array {
-            return array_map('strtoupper', $row);
-        };
-
-        $this->csv->addFormatter($func);
+        $this->csv->addFormatter(fn (array $row): array => array_map('strtoupper', $row));
         $this->csv->insertOne(['jane', 'doe']);
         self::assertSame("JANE,DOE\n", $this->csv->toString());
     }


### PR DESCRIPTION
Deprecating `TabularDataReader::fetchColumn` in favor of:

- `TabularDataReader::fetchColumnByName` for selecting column base on colunm name
- `TabularDataReader::fetchColumnByOffset` for selecting column base on colunm offset

To improve POLA (principle of least astonishment)