### PR TITLE
Use single quote to escape formulas

### DIFF
--- a/docs/9.0/interoperability/escape-formula-injection.md
+++ b/docs/9.0/interoperability/escape-formula-injection.md
@@ -14,14 +14,15 @@ The `EscapeFormula` Formatter formats CSV records to reduce [CSV Formula Injecti
 The `EscapeFormula` class uses the formatter capabilities of the `Writer` object to escape formula injection.
 
 ```php
-public function __construct(string $escape = "\t", array $special_chars = [])
+public function __construct(string $escape = "'", array $special_chars = [])
 public function __invoke(array $record): array
 ```
 
 The `EscapeFormula::__construct` method takes two (2) arguments:
 
-- the `$escape` parameter which will be used to prepend the record field, which default to `\t`;
-- the `$special_chars` parameter which is an `array` with additional characters that need to be escaped. By default the following characters if found at the start of any record field content will be escaped `+`,`-`,`=`,`@`;
+- the `$escape` parameter which will be used to prepend the record field, which default to `'`;
+- the `$special_chars` parameter which is an `array` with additional characters that need to be escaped. By default the following characters if found at the start of any record field content will be escaped `+`,`-`,`=`,`@`, `\t`, `\r`;
+- for more information see [OWASP - CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection)
 
 ```php
 use League\Csv\EscapeFormula;

--- a/src/EscapeFormula.php
+++ b/src/EscapeFormula.php
@@ -33,7 +33,7 @@ class EscapeFormula
     /**
      * Spreadsheet formula starting character.
      */
-    const FORMULA_STARTING_CHARS = ['=', '-', '+', '@'];
+    const FORMULA_STARTING_CHARS = ['=', '-', '+', '@', "\t", "\r"];
 
     /**
      * Effective Spreadsheet formula starting characters.
@@ -56,7 +56,7 @@ class EscapeFormula
      * @param string[] $special_chars additional spreadsheet formula starting characters
      *
      */
-    public function __construct(string $escape = "\t", array $special_chars = [])
+    public function __construct(string $escape = "'", array $special_chars = [])
     {
         $this->escape = $escape;
         if ([] !== $special_chars) {

--- a/src/EscapeFormulaTest.php
+++ b/src/EscapeFormulaTest.php
@@ -50,7 +50,7 @@ final class EscapeFormulaTest extends TestCase
     public function testGetEscape(): void
     {
         $formatter = new EscapeFormula();
-        self::assertSame("\t", $formatter->getEscape());
+        self::assertSame("'", $formatter->getEscape());
         $formatterBis = new EscapeFormula("\n");
         self::assertSame("\n", $formatterBis->getEscape());
     }
@@ -76,7 +76,7 @@ final class EscapeFormulaTest extends TestCase
     public function testEscapeRecord(): void
     {
         $record = ['2', '2017-07-25', 'Important Client', '=2+5', 240, null, (object) 'yes'];
-        $expected = ['2', '2017-07-25', 'Important Client', "\t=2+5", 240, null, (object) 'yes'];
+        $expected = ['2', '2017-07-25', 'Important Client', "'=2+5", 240, null, (object) 'yes'];
         $formatter = new EscapeFormula();
         self::assertEquals($expected, $formatter->escapeRecord($record));
     }
@@ -89,8 +89,8 @@ final class EscapeFormulaTest extends TestCase
      */
     public function testFormatterOnWriter(): void
     {
-        $record = ['2', '2017-07-25', 'Important Client', '=2+5', 240, null];
-        $expected = "2,2017-07-25,\"Important Client\",\"\t=2+5\",240,\n";
+        $record = ['2', '2017-07-25', 'Important Client', '=2+5', 240, "\ttab", "\rcr", null];
+        $expected = "2,2017-07-25,\"Important Client\",'=2+5,240,\"'\ttab\",\"'\rcr\",\n";
         $csv = Writer::createFromFileObject(new SplTempFileObject());
         $csv->addFormatter(new EscapeFormula());
         $csv->insertOne($record);


### PR DESCRIPTION
... and add tab ```\t``` and carriage return ```\r``` to escaped values.

As already used in symfony/serializer (https://symfony.com/blog/cve-2021-41270-prevent-csv-injection-via-formulas)
and as OWASP suggests in https://owasp.org/www-community/attacks/CSV_Injection

Credits for finding this issue in thephpleague/csv goes to @Lehmhub :dancing_men:  