### PR TITLE
Minor changes (public constants, strict comparison)

### DIFF
--- a/src/RFC4180Field.php
+++ b/src/RFC4180Field.php
@@ -90,7 +90,7 @@ class RFC4180Field extends php_user_filter
      */
     public static function addFormatterTo(Writer $csv, string $whitespace_replace): Writer
     {
-        if ('' == $whitespace_replace || strlen($whitespace_replace) !== strcspn($whitespace_replace, self::$force_enclosure)) {
+        if ('' === $whitespace_replace || strlen($whitespace_replace) !== strcspn($whitespace_replace, self::$force_enclosure)) {
             throw new InvalidArgumentException('The sequence contains a character that enforces enclosure or is a CSV control character or is the empty string.');
         }
 


### PR DESCRIPTION
- new PHP 7.4 migrations (yield from)
- marked class constants explicitly as public
- minor doc block updates
- replaced simple comparisons with strict comparison operator where types are obvious