### PR TITLE
Add sensible open mode default for Writer

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -32,6 +32,14 @@ class Writer extends AbstractCsv implements TabularDataWriter
     protected ?int $flush_threshold = null;
 
     /**
+     * {@inheritdoc}
+     */
+    public static function createFromPath(string $path, string $open_mode = 'w+b', $context = null)
+    {
+        return parent::createFromPath($path, $open_mode, $context);
+    }
+
+    /**
      * Returns the current newline sequence characters.
      */
     public function getNewline(): string


### PR DESCRIPTION
The documentation gives (at https://csv.thephpleague.com/9.0/writer/#inserting-records) the following example:

```php
$writer = Writer::createFromPath('/path/to/saved/file.csv', 'w+');
```

The second parameter, 'w+' is needed because the default open mode in `AbstractCsv.php` is 'r+', see https://github.com/thephpleague/csv/blob/master/src/AbstractCsv.php#L109

Since the purpose of the `Writer` class is to write, it seems a more sensible open mode default would be write (i.e. 'w+') rather than read.

This allows us to simplify usage to:

```php
$writer = Writer::createFromPath('/path/to/saved/file.csv');
```

Additionally, the PHP manual suggests using 'b' (at https://www.php.net/manual/en/function.fopen.php) so went for 'w+b' for a default.