### PR TITLE
Extraordinary proofing

### DIFF
--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -17,7 +17,7 @@ _(Please explain in plain english your question)_
 
 * [ ] Be sure that there isn't already an issue about this. See: [Issues list](https://github.com/thephpleague/csv/issues)
 * [ ] Be sure that there isn't already a pull request about this. See: [Pull requests](https://github.com/thephpleague/csv/pulls)
-* [ ] I have read, search and not found the information on the [documentation website](https://csv.thephpleague.com).
-* [ ] I have read, search and not found the information on PHP related forums and/or websites.
+* [ ] I have read, searched and not found the information on the [documentation website](https://csv.thephpleague.com).
+* [ ] I have read, searched and not found the information on PHP related forums and/or websites.
 * [ ] This issue is about 1 question around the package with no business or domain specific logic related to a specific situation.
 * [ ] The question has a descriptive title. For example:  "Can I use the library with compressed CSV documents ?".

--- a/.github/PULL_REQUEST_TEMPLATE/New_Feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/New_Feature.md
@@ -4,8 +4,8 @@ about: You have implemented some neat idea that you want to make part of League\
 ---
 
 <!--
-Thank you for submitting new feature!
-Pick the target branch based according to these criteria:
+Thank you for submitting a new feature!
+Pick the target branch according to these criteria:
   * submitting a bugfix: target the lowest active stable branch: 2.6
   * submitting a new feature: target the master branch.
   * submitting a BC-breaking change: target the master branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -357,11 +357,11 @@ protected methods `HTMLConverter::addHTMLAttributes` and `HTMLConverter::appendH
 ### Fixed
 
 - `AbstractCSV::__construct` correctly initializes properties
-- `AbstractCSV::createFromString` named constructor default argument is now the empty string
-- `AbstractCSV::setEscape` now accepts the empty string like `fputcsv` and `fgetcsv`
+- `AbstractCSV::createFromString` named constructor default argument is now an empty string
+- `AbstractCSV::setEscape` now accepts an empty string like `fputcsv` and `fgetcsv`
 - `Writer::insertOne` fixes throwing exception when record can not be inserted
 - `XMLConverter` convert to string the record value to avoid PHP warning on `null` value
-- Internal `Stream::createFromString` named constructor default argument is now the empty string
+- Internal `Stream::createFromString` named constructor default argument is now an empty string
 - Internal `Stream::fwrite` improved
 - Internal `Stream::__destruct` no longer emit warning on invalid stream filter removal.
 - Internal `Stream::seek` returns `0` if the seeked position `0` is valid see [#321](https://github.com/thephpleague/csv/pull/332) thanks [@HaozhouChen](https://github.com/HaozhouChen)
@@ -472,11 +472,11 @@ protected methods `HTMLConverter::addHTMLAttributes` and `HTMLConverter::appendH
 
 ### Added
 
-- Support for non seekable stream. When seekable feature are required an exceptions will be thrown.
+- Support for non-seekable stream. When seekable feature are required an exceptions will be thrown.
 - `League\Csv\EncloseField` to force enclosure insertion on every field. [#269](https://github.com/thephpleague/csv/pull/269)
 - `League\Csv\EscapeFormula` a League CSV formatter to prevent CSV Formula Injection in Spreadsheet programs.
 - `League\Csv\RFC4180Field::addTo` accept an option `$replace_whitespace` argument to improve RFC4180 compliance.
-- `League\Csv\Abstract::getContent` to replace `League\Csv\Abstract::__toString`. The `__toString` method may trigger a Fatal Error with non seekable stream, instead you are recommended to used the new `getContent` method which will trigger an exception instead.
+- `League\Csv\Abstract::getContent` to replace `League\Csv\Abstract::__toString`. The `__toString` method may trigger a Fatal Error with non-seekable stream, instead you are recommended to used the new `getContent` method which will trigger an exception instead.
 
 ### Deprecated
 
@@ -1062,7 +1062,7 @@ to manage BOM character with CSV.
 
 ### Fixed
 
-- `$open_mode` default to `r+` in `League\Csv\AbstractCsv` constructors
+- `$open_mode` defaults to `r+` in `League\Csv\AbstractCsv` constructors
 
 ### Removed
 
@@ -1099,8 +1099,8 @@ to manage BOM character with CSV.
 
 ### Fixed
 
-- `League\Csv\Reader::setOffset` now default to 0;
-- `League\Csv\Reader::setLimit` now default to -1;
+- `League\Csv\Reader::setOffset` now defaults to 0;
+- `League\Csv\Reader::setLimit` now defaults to -1;
 - `detectDelimiter` bug fixes
 
 ### Removed
@@ -1165,8 +1165,8 @@ to manage BOM character with CSV.
 
 - `toHTML` method bug in `Bakame\Csv\AbstractCsv`
 - `output` method accepts an optional `$filename` argument
-- `Bakame\Csv\Reader::fetchCol` default to `$columnIndex = 0`
-- `Bakame\Csv\Reader::fetchOne` default to `$offset = 0`
+- `Bakame\Csv\Reader::fetchCol` defaults to `$columnIndex = 0`
+- `Bakame\Csv\Reader::fetchOne` defaults to `$offset = 0`
 
 ## 4.1.2 - 2014-02-14
 

--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ composer require league/csv
 using the library to help [PHP detect line ending](http://php.net/manual/en/function.fgetcsv.php#refsect1-function.fgetcsv-returnvalues).
 
 ```php
-if (!ini_get("auto_detect_line_endings")) {
-    ini_set("auto_detect_line_endings", '1');
+if (!ini_get('auto_detect_line_endings')) {
+    ini_set('auto_detect_line_endings', '1');
 }
 ```
 
 ## Testing
 
-The library has a :
+The library has:
 
-- a [PHPUnit](https://phpunit.de) test suite
+- a [PHPUnit](https://phpunit.de) test suite.
 - a coding style compliance test suite using [PHP CS Fixer](https://cs.symfony.com/).
 - a code analysis compliance test suite using [PHPStan](https://github.com/phpstan/phpstan).
 

--- a/docs/7.0/basic-usage.md
+++ b/docs/7.0/basic-usage.md
@@ -36,7 +36,7 @@ echo $reader->__toString();
 
 If you only wish to make your CSV downloadable by forcing a file download just use the `output` method to force the use of the output buffer on the CSV content.
 
-<p class="message-notice"> Since <code>version 7.0</code>, the method returns the number of characters read from the handle and passed through to the output.</p>
+<p class="message-notice"> Since version <code>7.0</code>, the method returns the number of characters read from the handle and passed through to the output.</p>
 
 ```php
 header('Content-Type: text/csv; charset=UTF-8');

--- a/docs/7.0/converting.md
+++ b/docs/7.0/converting.md
@@ -11,9 +11,9 @@ When this is not possible/applicable you can fallback to using the `setEncodingF
 
 If your CSV is not UTF-8 encoded some unexpected results and some errors could be thrown when trying to convert your data.
 
-<p class="message-notice">Starting with <code>version 7.0</code>, when used with the <code>League\Csv\Reader</code> class, the conversion methods behavior are affected by the query options methods. Please refer to the <a href="/7.0/query-filtering">Query Filters page</a> for more information and examples.</p>
+<p class="message-notice">Starting with version <code>7.0</code>, when used with the <code>League\Csv\Reader</code> class, the conversion methods behavior are affected by the query options methods. Please refer to the <a href="/7.0/query-filtering">Query Filters page</a> for more information and examples.</p>
 
-<p class="message-notice">Starting with <code>version 7.1</code>,  query filters are also available for conversion methods when using the <code>League\Csv\Writer</code> class</p>
+<p class="message-notice">Starting with version <code>7.1</code>, query filters are also available for conversion methods when using the <code>League\Csv\Writer</code> class</p>
 
 ## Convert to JSON format
 

--- a/docs/7.0/instantiation.md
+++ b/docs/7.0/instantiation.md
@@ -85,11 +85,11 @@ $reader = Reader::createFromString('john,doe,john.doe@example.com', "\n");
 $writer = Writer::createFromString('john,doe,john.doe@example.com', "\r\n");
 ```
 
-<p class="message-warning">Starting with <code>version 7.0</code> directly using the default constructor is no longer possible.</p>
+<p class="message-warning">Starting with version <code>7.0</code> directly using the default constructor is no longer possible.</p>
 
 ## Switching from one class to the other
 
-At any given time you can switch or create a new `League\Csv\Writer` or a new `League\Csv\Reader` from the current object. to do so you can use the following methods.
+At any given time you can switch or create a new `League\Csv\Writer` or a new `League\Csv\Reader` from the current object. To do so, you can use the following methods.
 
 - the `newReader` to create a new `League\Csv\Reader` object;
 - the `newWriter` to create a new `League\Csv\Writer` object;

--- a/docs/7.0/properties.md
+++ b/docs/7.0/properties.md
@@ -68,7 +68,7 @@ $flags = $csv->getFlags(); //returns an integer
 The method takes two arguments:
 
 - an array containing the delimiters to check;
-- an integer which represents the number of rows to scan (default to `1`);
+- an integer which represents the number of rows to scan (defaults to `1`);
 
 ```php
 $reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
@@ -101,7 +101,7 @@ If you are no sure about the delimiter you can ask the library to detect it for 
 
 The method takes two arguments:
 
-- the number of rows to scan (default to `1`);
+- the number of rows to scan (defaults to `1`);
 - the possible delimiters to check (you don't need to specify the following delimiters as they are already checked by the method: `",", ";", "\t"`);
 
 ```php

--- a/docs/7.0/query-filtering.md
+++ b/docs/7.0/query-filtering.md
@@ -16,9 +16,9 @@ You can restrict [extract methods](/7.0/reading/) and [conversion methods](/7.0/
 
 <p class="message-info">The options methods are described in the same order as they are applied on the CSV iterator. The order is similar to one found in SQL statement construct.</p>
 
-<p class="message-notice">Starting with <code>version 7.0</code> The query options can be use to modify the output from the <code>jsonSerialize</code>, <code>toXML</code> and <code>toHTML</code> methods.</p>
+<p class="message-notice">Starting with version <code>7.0</code> The query options can be use to modify the output from the <code>jsonSerialize</code>, <code>toXML</code> and <code>toHTML</code> methods.</p>
 
-<p class="message-notice">Starting with <code>version 7.1</code> The query options are also available for conversion methods on the <code>League\Csv\Writer</code> class.</p>
+<p class="message-notice">Starting with version <code>7.1</code> The query options are also available for conversion methods on the <code>League\Csv\Writer</code> class.</p>
 
 ## Modifying content methods
 

--- a/docs/7.0/reading.md
+++ b/docs/7.0/reading.md
@@ -117,7 +117,7 @@ $data = $reader->fetchColumn(2);
 ```
 
 <div class="message-warning">
-<strong>BC break starting with <code>version 7.0</code> :</strong>
+<strong>BC break starting with version <code>7.0</code> :</strong>
 <ul>
 <li>This method no longer adds <code>null</code> on an non existing column index.</li>
 <li>The cell skipping is done on the callable result.</li>

--- a/docs/8.0/instantiation.md
+++ b/docs/8.0/instantiation.md
@@ -98,7 +98,7 @@ $writer = Writer::createFromString('john,doe,john.doe@example.com');
 
 ### AbstractCsv::createFromStream
 
-<p class="message-notice">New since <code>version 8.2.0</code></p>
+<p class="message-notice">New since version <code>8.2.0</code></p>
 
 This named constructor will create a new object from a stream resource.
 
@@ -118,7 +118,7 @@ $writer = Writer::createFromStream(fopen('php://temp', 'r+'));
 
 ## Switching from one class to the other
 
-At any given time you can switch or create a new `League\Csv\Writer` or a new `League\Csv\Reader` from the current object. to do so you can use the following methods.
+At any given time you can switch or create a new `League\Csv\Writer` or a new `League\Csv\Reader` from the current object. To do so, you can use the following methods.
 
 - the `newReader` to create a new `League\Csv\Reader` object;
 - the `newWriter` to create a new `League\Csv\Writer` object;

--- a/docs/8.0/properties.md
+++ b/docs/8.0/properties.md
@@ -8,7 +8,7 @@ redirect_from: /properties/
 
 Once your object is [instantiated](/8.0/instantiation/) you can optionally set several CSV properties. The following methods works on both the `Reader` and the `Writer` class.
 
-<p class="message-notice">Since <code>version 8.1.1</code> The underlying CSV controls from the submitted CSV are inherited by the return <code>AbstractCsv</code> object.</p>
+<p class="message-notice">Since version <code>8.1.1</code> The underlying CSV controls from the submitted CSV are inherited by the return <code>AbstractCsv</code> object.</p>
 
 ```php
 $file = new SplTempFileObject();
@@ -110,7 +110,7 @@ public AbstractCsv::fetchDelimitersOccurrence(
 The method takes two arguments:
 
 - an array containing the delimiters to check;
-- an integer which represents the number of rows to scan (default to `1`);
+- an integer which represents the number of rows to scan (defaults to `1`);
 
 ```php
 use League\Csv\Reader;

--- a/docs/8.0/reading.md
+++ b/docs/8.0/reading.md
@@ -132,7 +132,7 @@ $nbRows = $reader->each(function ($row) {
 
 ## Reader::fetchAssoc
 
-<p class="message-warning"><strong>BC Break:</strong> Starting with <code>version 8.0.0</code> This method returns an <code>Iterator</code>.</p>
+<p class="message-warning"><strong>BC Break:</strong> Starting with version <code>8.0.0</code> This method returns an <code>Iterator</code>.</p>
 
 `fetchAssoc` returns an `Iterator` of all rows. The rows themselves are associative arrays where the keys are a one dimension array. This array must only contain unique `string` and/or `scalar` values.
 
@@ -226,7 +226,7 @@ foreach ($reader->fetchAssoc($keys, $func) as $row) {
 
 ## Reader::fetchColumn
 
-<p class="message-warning"><strong>BC Break:</strong> Starting with <code>version 8.0.0</code> This method returns a <code>Iterator</code>.</p>
+<p class="message-warning"><strong>BC Break:</strong> Starting with version <code>8.0.0</code> This method returns a <code>Iterator</code>.</p>
 
 `fetchColumn` returns a `Iterator` of all values in a given column from the CSV data.
 
@@ -280,7 +280,7 @@ foreach ($reader->fetchColumn(2, 'strtoupper') as $value) {
 
 ## Reader::fetchPairs
 
-<p class="message-notice">new feature introduced in <code>version 8.0</code></p>
+<p class="message-notice">new feature introduced in version <code>8.0</code></p>
 
 The `fetchPairs` method returns a `Generator` of key-value pairs.
 
@@ -300,7 +300,7 @@ public Reader::fetchPairs(
 ```php
 use League\Csv\Reader;
 
-$str = <<EOF
+$str = <<<EOF
 john,doe
 jane,doe
 foo,bar
@@ -322,8 +322,8 @@ foreach ($reader->fetchPairs() as $firstname => $lastname) {
 
 ### Notes
 
-- If no `$offsetIndex` is provided it default to `0`;
-- If no `$valueIndex` is provided it default to `1`;
+- If no `$offsetIndex` is provided it defaults to `0`;
+- If no `$valueIndex` is provided it defaults to `1`;
 - If no cell is found corresponding to `$offsetIndex` the row is skipped;
 - If no cell is found corresponding to `$valueIndex` the `null` value is used;
 
@@ -346,7 +346,7 @@ function(array $pairs [, int $rowOffset [, Iterator $iterator]]): array
 ```php
 use League\Csv\Reader;
 
-$str = <<EOF
+$str = <<<EOF
 john,doe
 jane,doe
 foo,bar
@@ -374,7 +374,7 @@ foreach ($reader->fetchPairs(1, 0, $func) as $lastname => $firstname) {
 
 ## Reader::fetchPairsWithoutDuplicates
 
-<p class="message-notice">new feature introduced in <code>version 8.0</code></p>
+<p class="message-notice">new feature introduced in version <code>8.0</code></p>
 
 The `fetchPairsWithoutDuplicates` method returns data in an `array` of key-value pairs, as an associative array with a single entry per row.
 
@@ -392,7 +392,7 @@ public Reader::fetchPairsWithoutDuplicates(
 - When using `fetchPairsWithoutDuplicates` entries in the associative array will be overwritten if there are duplicates values in the column index.
 
 ```php
-$str = <<EOF
+$str = <<<EOF
 john,doe
 jane,doe
 foo,bar

--- a/docs/9.0/connections/bom.md
+++ b/docs/9.0/connections/bom.md
@@ -37,7 +37,7 @@ Info::fetchBOMSequence('hello world!'.Info::BOM_UTF16_BE); //returns null
 
 ### bom_match
 
-<p class="message-warning">Since <code>version 9.7</code> this function is deprecated and you are encouraged to use <code>Info::fetchBOMSequence</code> instead.</p>
+<p class="message-warning">Since version <code>9.7</code> this function is deprecated and you are encouraged to use <code>Info::fetchBOMSequence</code> instead.</p>
 
 ```php
 function League\Csv\bom_match(string $str): string
@@ -79,7 +79,7 @@ public AbstractCsv::getOutputBOM(void): string
 ```
 
 - `setOutputBOM`: sets the outputting BOM you want your CSV to be associated with.
-- `getOutputBOM`: get the outputting BOM you want your CSV to be associated with.
+- `getOutputBOM`: gets the outputting BOM you want your CSV to be associated with.
 
 <p class="message-info">All connections classes implement the <code>ByteSequence</code> interface.</p>
 
@@ -98,7 +98,7 @@ $bom = $csv->getOutputBOM(); //returns "\xEF\xBB\xBF"
 
 <p class="message-info">Since version <code>9.4.0</code>.</p>
 
-If your document contains a BOM sequence by the following methods control its presence when processing it.
+If your document contains a BOM sequence the following methods control its presence when processing it.
 
 ```php
 AbstractCsv::skipInputBOM(): self;
@@ -112,7 +112,7 @@ AbstractCsv::isInputBOMIncluded(): bool;
 
 <p class="message-notice">By default and to avoid BC Break, the Input BOM, if present, is skipped.</p>
 
-If your document does not contains any BOM sequence you can speed up the CSV iterator by preserving its presence which means that no operation to detect and remove it if present will take place.
+If your document does not contain any BOM sequence you can speed up the CSV iterator by preserving its presence, which means that no operation to detect and remove it if present will take place.
 
 ```php
 $raw_csv = Reader::BOM_UTF8."john,doe,john.doe@example.com\njane,doe,jane.doe@example.com\n";
@@ -124,7 +124,7 @@ $csv->output();
 $document = ob_get_clean();
 ```
 
-The returned `$document` will contains **2** BOM marker instead of one.
+The returned `$document` will contain **2** BOM markers instead of one.
 
-<p class="message-warning">If you are using a <code>stream</code> that can not be seekable you should disable BOM skipping otherwise an <code>Exception</code> will be triggered.</p>
+<p class="message-warning">If you are using a <code>stream</code> that can not be seekable you should disable BOM skipping, otherwise an <code>Exception</code> will be triggered.</p>
 <p class="message-warning">The BOM sequence is never removed from the CSV document, it is only skipped from the result set.</p>

--- a/docs/9.0/connections/controls.md
+++ b/docs/9.0/connections/controls.md
@@ -55,7 +55,7 @@ $enclosure = $csv->getEnclosure(); //returns "|"
 
 ## The escape character
 
-This is PHP specific control character which sometimes interfere with CSV parsing and writing. It is recommended in version preceding `9.2.0` to never change its default value unless you do understand its usage and its consequences.
+This is a PHP specific control character which sometimes interferes with CSV parsing and writing. It is recommended in versions preceding `9.2.0` to never change its default value unless you do understand its usage and its consequences.
 
 ### Description
 
@@ -78,7 +78,7 @@ $escape = $csv->getEscape(); //returns "\"
 
 <p class="message-notice">Since version <code>9.2.0</code> you can provide an empty string for the escape character to enable better <a href="https://tools.ietf.org/html/rfc4180">RFC4180</a> compliance.</p>
 
-<p class="message-warning"><code>setEscape</code> will throw a <code>Exception</code> exception if the submitted string length is not equal to <code>1</code> byte or the empty string.</p>
+<p class="message-warning"><code>setEscape</code> will throw a <code>Exception</code> exception if the submitted string length is not equal to <code>1</code> byte or an empty string.</p>
 
 ```php
 use League\Csv\Reader;
@@ -107,26 +107,26 @@ echo $csv->getEscape();    //display '\'
 ## Detecting the delimiter character
 
 ```php
-function League\Csv\Info::getDelimiterStats(Reader $csv, array $delimiters, $limit = 1): array
+function League\Csv\Info::getDelimiterStats(Reader $csv, array $delimiters, int $limit = 1): array
 ```
 
 or
 
 ```php
-function League\Csv\delimiter_detect(Reader $csv, array $delimiters, $limit = 1): array
+function League\Csv\delimiter_detect(Reader $csv, array $delimiters, int $limit = 1): array
 ```
 
-<p class="message-warning">Since <code>version 9.7</code> this function is deprecated and you are encouraged to use <code>Info::getDelimiterStats</code> instead.</p>
+<p class="message-warning">Since version <code>9.7</code> this function is deprecated and you are encouraged to use <code>Info::getDelimiterStats</code> instead.</p>
 
 The `Info::getDelimiterStats` static method helps detect the possible delimiter character used by the CSV document. This function returns the number of CSV fields found in the document depending on the submitted delimiters given.
 
 The function takes three (3) arguments:
 
-- a [Reader](/9.0/reader/) object
+- a [Reader](/9.0/reader/) object;
 - an array containing the delimiters to check;
-- an integer which represents the number of CSV records to scan (default to `1`);
+- an integer which represents the number of CSV records to scan (defaults to `1`);
 
-and returns an associated array whose keys are the submitted delimiters characters and whose values represents the field numbers found depending on the delimiter value.
+and returns an associated array whose keys are the submitted delimiters characters and whose values represent the field numbers found depending on the delimiter value.
 
 ```php
 use League\Csv\Info;
@@ -151,4 +151,4 @@ If the submitted delimiter **is invalid or not found** in the document, `0` will
 
 <p class="message-info">To detect the delimiters stats on the full CSV document you need to set <code>$limit</code> to <code>-1</code>.</p>
 <p class="message-notice">This function only returns hints. Only the CSV providers will validate the real CSV delimiter character.</p>
-<p class="message-warning">This function only test the delimiters you gave it.</p>
+<p class="message-warning">This function only tests the delimiters you pass it.</p>

--- a/docs/9.0/connections/filters.md
+++ b/docs/9.0/connections/filters.md
@@ -26,12 +26,12 @@ use League\Csv\Reader;
 use League\Csv\Writer;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
-$reader->supportsStreamFilterOnRead(); //return true
-$reader->supportsStreamFilterOnWrite(); //return false
+$reader->supportsStreamFilterOnRead(); //returns true
+$reader->supportsStreamFilterOnWrite(); //returns false
 
 $writer = Writer::createFromFileObject(new SplTempFileObject());
-$writer->supportsStreamFilterOnRead(); // returns false, the API can not be used
-$writer->supportsStreamFilterOnWrite(); // returns false, the API can not be used
+$writer->supportsStreamFilterOnRead(); //returns false, the API can not be used
+$writer->supportsStreamFilterOnWrite(); //returns false, the API can not be used
 ```
 
 <p class="message-notice">The following methods still work but are deprecated since version <code>9.7.0</code></p>
@@ -47,22 +47,22 @@ The filter mode value is one of the following PHP's constant:
 - `STREAM_FILTER_READ` to add stream filter on read
 - `STREAM_FILTER_WRITE` to add stream filter on write
 
-Regardless of stream filter API support by a specific CSV object, `getStreamFilterMode` will always return a value.
+Regardless of the stream filter API being supported by a specific CSV object, `getStreamFilterMode` will always return a value.
 
 ```php
 use League\Csv\Reader;
 use League\Csv\Writer;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
-$reader->supportsStreamFilter(); //return true
-$reader->getStreamFilterMode(); //return STREAM_FILTER_READ
+$reader->supportsStreamFilter(); //returns true
+$reader->getStreamFilterMode(); //returns STREAM_FILTER_READ
 
 $writer = Writer::createFromFileObject(new SplTempFileObject());
-$writer->supportsStreamFilter(); // returns false, the API can not be used
-$writer->getStreamFilterMode(); // returns STREAM_FILTER_WRITE
+$writer->supportsStreamFilter(); //returns false, the API can not be used
+$writer->getStreamFilterMode(); //returns STREAM_FILTER_WRITE
 ```
 
-<p class="message-warning">A <code>League\Csv\Exception</code> exception will be thrown if you use the API on a object where <code>supportsStreamFilter</code> returns <code>false</code>.</p>
+<p class="message-warning">A <code>League\Csv\Exception</code> exception will be thrown if you use the API on an object where <code>supportsStreamFilter</code> returns <code>false</code>.</p>
 
 ### Cheat sheet
 
@@ -86,7 +86,7 @@ The `AbstractCsv::addStreamFilter` method adds a stream filter to the connection
 
 - The `$filtername` parameter is a string that represents the filter as registered using php `stream_filter_register` function or one of [PHP internal stream filter](http://php.net/manual/en/filters.php).
 
-- The `$params` : This filter will be added with the specified paramaters to the end of the list.
+- The `$params` : This filter will be added with the specified parameters to the end of the list.
 
 <p class="message-warning">Each time your call <code>addStreamFilter</code> with the same argument the corresponding filter is registered again.</p>
 
@@ -143,7 +143,7 @@ $reader = null;
 
 ## Bundled stream filters
 
-The library comes bundle with two (2) stream filters:
+The library comes bundled with two (2) stream filters:
 
 - [RFC4180Field](/9.0/interoperability/rfc4180-field/) stream filter to read or write RFC4180 compliant CSV field;
 - [CharsetConverter](/9.0/converter/charset/) stream filter to convert your CSV document content using the `mbstring` extension;

--- a/docs/9.0/connections/index.md
+++ b/docs/9.0/connections/index.md
@@ -7,7 +7,7 @@ title: CSV documents configurations
 
 ## Connection type
 
-Accessing the CSV document is done using one of the following class:
+Accessing the CSV document is done using one of the following classes:
 
 - `League\Csv\Reader` to connect on a [read only mode](/9.0/reader/)
 - `League\Csv\Writer` to connect on a [write only mode](/9.0/writer/)
@@ -25,8 +25,8 @@ Both classes extend the `League\Csv\AbstractCsv` class and as such share the fol
 If your CSV document was created or is read on a Macintosh computer, add the following lines before using the library to help [PHP detect line ending in Mac OS X](http://php.net/manual/en/function.fgetcsv.php#refsect1-function.fgetcsv-returnvalues).
 
 ```php
-if (!ini_get("auto_detect_line_endings")) {
-    ini_set("auto_detect_line_endings", '1');
+if (!ini_get('auto_detect_line_endings')) {
+    ini_set('auto_detect_line_endings', '1');
 }
 
 //the rest of the code continues here...
@@ -48,7 +48,7 @@ try {
 }
 ```
 
-When using a non-seekable `SplFileObject`, a `RuntimeException` is thrown instead of a `League\Csv\Exception` when using features that requires a seekable CSV document. In the following example a seekable CSV document is required to update the inserted newline.
+When using a non-seekable `SplFileObject`, a `RuntimeException` is thrown instead of a `League\Csv\Exception` when using features that require a seekable CSV document. In the following example a seekable CSV document is required to update the inserted newline.
 
 ```php
 use League\Csv\Exception;

--- a/docs/9.0/connections/instantiation.md
+++ b/docs/9.0/connections/instantiation.md
@@ -7,12 +7,12 @@ title: Loading CSV documents
 
 Because CSV documents come in different forms we use named constructors to offer several ways to load them.
 
-<p class="message-warning">Since version <code>9.1.0</code> non seekable CSV documents can be used but <strong>exceptions will be thrown if features requiring seekable CSV document are used.</strong></p>
+<p class="message-warning">Since version <code>9.1.0</code> non-seekable CSV documents can be used but <strong>exceptions will be thrown if features requiring a seekable CSV document are used.</strong></p>
 
 ## Loading from a string
 
 ```php
-public static AbstractCsv::createFromString(string $str = ''): self
+public static AbstractCsv::createFromString(string $content = ''): self
 ```
 
 Creates a new object from a given string.
@@ -25,7 +25,7 @@ $reader = Reader::createFromString('john,doe,john.doe@example.com');
 $writer = Writer::createFromString('john,doe,john.doe@example.com');
 ```
 
-<p class="message-notice">Since version <code>9.2.0</code> the <code>$str</code> argument default value is the empty string to ease usage.</p>
+<p class="message-notice">Since version <code>9.2.0</code> the <code>$content</code> argument default value is an empty string to ease usage.</p>
 
 ## Loading from a file path
 
@@ -43,13 +43,12 @@ Creates a new object *à la* `fopen`.
 use League\Csv\Reader;
 use League\Csv\Writer;
 
-
 $reader = Reader::createFromPath('/path/to/your/csv/file.csv', 'r');
 $writer = Writer::createFromPath('/path/to/your/csv/file.csv', 'w');
 ```
 
 <div class="message-notice">
-Starting with version <code>9.1.0</code>, <code>$open_mode</code> default to:
+Starting with version <code>9.1.0</code>, <code>$open_mode</code> defaults to:
 <ul>
 <li><code>r+</code> for the <code>Writer</code> class</li>
 <li><code>r</code> for the <code>Reader</code> class</li>
@@ -72,12 +71,12 @@ $reader = Reader::createFromStream(fopen('/path/to/the/file.csv', 'r+'));
 $writer = Writer::createFromStream(tmpfile());
 ```
 
-<p class="message-notice">Prior to version <code>9.1.0</code>, the method was throwing <code>League\Csv\Exception</code> for non-seekable stream resource.</p>
+<p class="message-notice">Prior to version <code>9.1.0</code>, the method would throw a <code>League\Csv\Exception</code> for a non-seekable stream resource.</p>
 
 ## Loading from a SplFileObject object
 
 ```php
-public static AbstractCsv::createFromFileObject(SplFileObject $obj): self
+public static AbstractCsv::createFromFileObject(SplFileObject $file): self
 ```
 
 Creates a new object from a `SplFileObject` object.
@@ -95,7 +94,7 @@ $writer = Writer::createFromFileObject(new SplTempFileObject());
 <p class="message-notice">New in version <code>9.2.0</code></p>
 
 ```php
-public static AbstractCsv::getPathname(): string
+public AbstractCsv::getPathname(): string
 ```
 
 Once instantiated, the `getPathname` method returns the pathname of the underlying document.
@@ -107,5 +106,5 @@ use League\Csv\Writer;
 Reader::createFromFileObject(new SplFileObject('/path/to/your/csv/file.csv'))->getPathname();
 //returns '/path/to/your/csv/file.csv'
 Writer::createFromFileObject(new SplTempFileObject())->getPathname();
-// returns php://temp
+//returns php://temp
 ```

--- a/docs/9.0/connections/output.md
+++ b/docs/9.0/connections/output.md
@@ -13,7 +13,7 @@ The output methods **are affected by** [the output BOM sequence](/9.0/connection
 
 ## Printing the document
 
-Returns the string representation of the CSV document
+Returns the string representation of the CSV document.
 
 ```php
 public AbstractCsv::toString(void): string
@@ -24,7 +24,7 @@ public AbstractCsv::__toString(void): string
 <p class="message-notice">The <code>toString</code> method is added in version <code>9.7.0</code> and replaces the <code>getContent</code> method which is <strong>deprecated</strong>.</p>
 <p class="message-notice">The <code>getContent</code> method is added in version <code>9.1.0</code> and replaces the <code>__toString</code> method which is <strong>deprecated</strong>.</p>
 
-Use the `toString` method to return the CSV full content.
+Use the `toString` method to return the full CSV content.
 
 ### Example
 
@@ -47,7 +47,7 @@ use League\Csv\Writer;
 $csv = Writer::createFromFileObject(new SplFileObject('php://output', 'w'));
 $csv->insertOne(['foo', 'bar']);
 echo $csv->toString();
-//throws an RuntimeException because the SplFileObject is not seekable
+//throws a RuntimeException because the SplFileObject is not seekable
 ```
 
 #### Using the `__toString` or `getContent` methods
@@ -62,7 +62,7 @@ echo $csv->getContent();
 //throws a Fatal Error because no exception can be thrown by the __toString method
 ```
 
-<p class="message-warning">The <code>__toString</code> method is deprecated in version <code>9.1.0</code> and will be remove in the next major version.</p>
+<p class="message-warning">The <code>__toString</code> method is deprecated in version <code>9.1.0</code> and will be removed in the next major version.</p>
 
 ## Downloading the document
 
@@ -74,8 +74,7 @@ public AbstractCsv::output(string $filename = null): int
 
 The method returns the number of characters read from the handle and passed through to the output.
 
-The output method can take an optional argument `$filename`. When present you
-can even remove more headers.
+The output method can take an optional argument `$filename`. When present you can even remove more headers.
 
 ### Default usage
 
@@ -97,11 +96,11 @@ die;
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('file.csv');
-$reader->output("name-for-your-file.csv");
+$reader->output('name-for-your-file.csv');
 die;
 ```
 
-<p class="message-notice">If you just need to make the CSV downloadable, end your script with a call to <code>exit</code> just after the <code>output</code> method. You <strong>should not</strong> return the method returned value.</p>
+<p class="message-notice">If you just need to make the CSV downloadable, end your script with a call to <code>die</code> just after the <code>output</code> method. You <strong>should not</strong> return the method returned value.</p>
 
 <p class="message-warning">starting with version <code>9.1.0</code>, the <code>output</code> method will throw an <code>Exception</code> if the provided <code>$filename</code> does not comply with <a href="https://tools.ietf.org/html/rfc6266#section-4">RFC6266</a></p>
 
@@ -113,7 +112,7 @@ public AbstractCsv::chunk(int $length): Generator
 
 The `AbstractCsv::chunk` method takes a single `$length` parameter specifying the number of bytes to read from the CSV document and returns a `Generator` to ease outputting large CSV files.
 
-<p class="message-warning">if the <code>$length</code> parameter is not a positive integer a <code>OutOfRangeException</code> will be thrown.</p>
+<p class="message-warning">If the <code>$length</code> parameter is not a positive integer an <code>OutOfRangeException</code> will be thrown.</p>
 
 ```php
 use League\Csv\Reader;
@@ -148,7 +147,7 @@ return new Response($reader->getContent(), 200, [
 ```
 
 In some cases you can also use a Streaming Response for larger files.
-The following example uses Symfony's [StreamedResponse](http://symfony.com/doc/current/components/http_foundation/introduction.html#streaming-a-response) object.
+The following example uses Symfony's [StreamedResponse](https://symfony.com/doc/current/components/http_foundation.html#streaming-a-response) object.
 
 <p class="message-notice"><i>Be sure to adapt the following code to your own framework/situation. The following code is given as an example without warranty of it working out of the box.</i></p>
 
@@ -157,7 +156,7 @@ use League\Csv\Writer;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
-//We generate the CSV using the Writer object
+//we generate the CSV using the Writer object
 //$dbh is a PDO object
 $stmt = $dbh->prepare("SELECT * FROM users");
 $stmt->setFetchMode(PDO::FETCH_ASSOC);
@@ -165,7 +164,7 @@ $stmt->execute();
 $csv = Writer::createFromPath('php://temp', 'r+');
 $csv->insertAll($stmt);
 
-//we create a callable to output the CSV in chunk
+//we create a callable to output the CSV in chunks
 //with Symfony StreamResponse you can flush the body content if necessary
 //see Symfony documentation for more information
 $flush_threshold = 1000; //the flush value should depend on your CSV size.
@@ -178,7 +177,7 @@ $content_callback = function () use ($csv, $flush_threshold) {
     }
 };
 
-//We send the CSV using Symfony StreamedResponse
+//we send the CSV using Symfony StreamedResponse
 $response = new StreamedResponse();
 $response->headers->set('Content-Encoding', 'none');
 $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');
@@ -196,9 +195,9 @@ $response->send();
 
 ### Notes
 
-The output methods **can only be affected by:**
+The output methods **can only be affected by**:
 
-- the [library stream filtering mechanism](/8.0/filtering/)
-- the [BOM property](/8.0/bom/)
+- the [library stream filtering mechanism](/9.0/connections/filtering/)
+- the [BOM property](/9.0/connections/bom/)
 
-No other method or property have effect on them.
+No other method or property has an effect on them.

--- a/docs/9.0/converter/charset.md
+++ b/docs/9.0/converter/charset.md
@@ -14,7 +14,7 @@ public CharsetConverter::inputEncoding(string $input_encoding): self
 public CharsetConverter::outputEncoding(string $output_encoding): self
 ```
 
-The `inputEncoding` and `outputEncoding` methods sets the object encoding properties. By default, the input encoding and the output encoding are set to `UTF-8`.
+The `inputEncoding` and `outputEncoding` methods set the object encoding properties. By default, the input encoding and the output encoding are set to `UTF-8`.
 
 When building a `CharsetConverter` object, the methods do not need to be called in any particular order, and may be called multiple times. Because the `CharsetConverter` is immutable, each time its setter methods are called they return a new object without modifying the current one.
 
@@ -46,7 +46,7 @@ The resulting data is converted from `iso-8859-15` to the default `UTF-8` since 
 public CharsetConverter::__invoke(array $record): array
 ```
 
-Using the `CharsetConverter::__invoke` method, you can register a `CharsetConverter` object as a record formatter using [Writer::addFormatter](/9.0/writer/#record-formatter) method.
+Using the `CharsetConverter::__invoke` method, you can register a `CharsetConverter` object as a record formatter using the [Writer::addFormatter](/9.0/writer/#record-formatter) method.
 
 ```php
 use League\Csv\CharsetConverter;
@@ -74,12 +74,12 @@ public static CharsetConverter::getFiltername(string $input_encoding, string $ou
 
 ### Usage with CSV objects
 
-If your CSV object supports PHP stream filters then you can use the `CharsetConverter` class as a PHP stream filter and use the library [stream filtering mechanism](/9.0/connections/filters/) instead.
+If your CSV object supports PHP stream filters then you can use the `CharsetConverter` class as a PHP stream filter using the library [stream filtering mechanism](/9.0/connections/filters/) instead.
 
 The `CharsetConverter::addTo` static method:
 
-- registers the `CharsetConverter` class under the following generic filtername `convert.league.csv.*` if it is not registered yet.
-- configures the stream filter using the supplied parameters.
+- registers the `CharsetConverter` class under the generic filtername `convert.league.csv.*` if it is not registered yet;
+- configures the stream filter using the supplied parameters;
 - adds the configured stream filter to the submitted CSV object;
 
 ```php

--- a/docs/9.0/converter/html.md
+++ b/docs/9.0/converter/html.md
@@ -5,13 +5,13 @@ title: Converting a CSV into an HTML table
 
 # HTML conversion
 
-The `HTMLConverter` converts a CSV records collection into a HTML Table using PHP's `DOMDocument` class.
+The `HTMLConverter` converts a CSV records collection into an HTML Table using PHP's `DOMDocument` class.
 
 ## Settings
 
-Prior to converting your records collection into a HTML table, you may wish to configure optional information to improve your table rendering.
+Prior to converting your records collection into an HTML table, you may wish to configure optional information to improve your table rendering.
 
-<p class="message-warning">Because we are using internally the <a href="/9.0/converter/xml/">XMLConverter</a>, if an error occurs while validating the submitted values a <code>DOMException</code> exception will be thrown.</p>
+<p class="message-warning">Because we are using the <a href="/9.0/converter/xml/">XMLConverter</a> internally, if an error occurs while validating the submitted values, a <code>DOMException</code> exception will be thrown.</p>
 
 ### HTMLConverter::table
 
@@ -19,10 +19,10 @@ Prior to converting your records collection into a HTML table, you may wish to c
 public HTMLConverter::table(string $class_name, string $id_value = ''): self
 ```
 
-This method sets the optional table `class` and `id` attribute values
+This method sets the optional table `class` and `id` attribute values.
 
 <p class="message-info">The default <code>class</code> attribute value is <code>table-csv-data</code>.</p>
-<p class="message-info">The default <code>id</code> attribute value is the empty string.</p>
+<p class="message-info">The default <code>id</code> attribute value is an empty string.</p>
 
 ### HTMLConverter::tr
 
@@ -32,7 +32,7 @@ public HTMLConverter::tr(string $record_offset_attribute_name): self
 
 This method sets the optional attribute name for the record offset on the HTML `tr` tag.
 
-<p class="message-info">If none is use or an empty string is given, the record offset information won't be exported to the HTML table.</p>
+<p class="message-info">If none is used or an empty string is given, the record offset information won't be exported to the HTML table.</p>
 
 ### HTMLConverter::td
 
@@ -42,7 +42,7 @@ public HTMLConverter::td(string $fieldname_attribute_name): self
 
 This method sets the optional attribute name for the field name on the HTML `td` tag.
 
-<p class="message-info">If none is use or an empty string is given, the field name information won't be exported to the HTML table.</p>
+<p class="message-info">If none is used or an empty string is given, the field name information won't be exported to the HTML table.</p>
 
 ## Conversion
 
@@ -55,10 +55,10 @@ public HTMLConverter::convert(iterable $records, array $header_record = [], arra
 The `HTMLConverter::convert` accepts an `iterable` which represents the records collection and returns a string.
 It optionally accepts:
 
-- an array of string representing the tabular header;
-- an array of string representing the tabular footer;
+- an array of strings representing the tabular header;
+- an array of strings representing the tabular footer;
 
-If any of these array is present and non-empty the tabular data will be contained in a `tbody` tag as per HTML specification.
+If any of these arrays are present and non-empty, the tabular data will be contained in a `tbody` tag as per HTML specification.
 
 ```php
 use League\Csv\HTMLConverter;

--- a/docs/9.0/converter/index.md
+++ b/docs/9.0/converter/index.md
@@ -11,7 +11,7 @@ The package provides classes which convert any collection of CSV records into:
 
 - another collection encoded using the [CharsetConverter](/9.0/converter/charset/) class;
 - a `DOMDocument` object using the [XMLConverter](/9.0/converter/xml/) class;
-- a HTML table using the [HTMLConverter](/9.0/converter/html/) class;
+- an HTML table using the [HTMLConverter](/9.0/converter/html/) class;
 
 <p class="message-warning"><strong>Warning:</strong> A <code>League\Csv\Writer</code> object can not be converted.</p>
 
@@ -23,4 +23,4 @@ When building a converter object, the methods do not need to be called in any pa
 
 ## Converters exceptions
 
-Because converters do not directly deals with CSV document but with their contents. On error theses classes trigger PHP's Exceptions instead of `League\Csv\Exception` exception.
+Because converters do not directly deals with CSV document but with their contents. On error these classes trigger PHP's Exceptions instead of `League\Csv\Exception` exception.

--- a/docs/9.0/converter/xml.md
+++ b/docs/9.0/converter/xml.md
@@ -9,7 +9,7 @@ The `XMLConverter` converts a CSV records collection into a PHP `DOMDocument`.
 
 ## Settings
 
-Prior to converting your records collection into XML, you may wish to configure the element and its associated attribute names. To do so `XMLConverter` provides methods to setup theses settings.
+Prior to converting your records collection into XML, you may wish to configure the element and its associated attribute names. To do so, `XMLConverter` provides methods to set up these settings.
 
 <p class="message-warning">Because we are building a <code>DOMDocument</code> object, the <code>XMLConverter</code> object throws <code>DOMException</code> instead of <code>League\Csv\Exception</code>.</p>
 
@@ -32,7 +32,7 @@ public XMLConverter::recordElement(string $node_name, string $record_offset_attr
 This method sets the XML record name and optionally the attribute name for the record offset value if you want this information preserved.
 
 <p class="message-info">The default record element name is <code>row</code>.</p>
-<p class="message-info">The default attribute name is the empty string.</p>
+<p class="message-info">The default attribute name is an empty string.</p>
 
 ### XMLConverter::fieldElement
 
@@ -43,7 +43,7 @@ public XMLConverter::fieldElement(string $node_name, string $fieldname_attribute
 This method sets the XML field name and optionally the attribute name for the field name value.
 
 <p class="message-info">The default field element name is <code>cell</code>.</p>
-<p class="message-info">The default attribute name is the empty string.</p>
+<p class="message-info">The default attribute name is an empty string.</p>
 
 ## Conversion
 
@@ -105,7 +105,7 @@ echo htmlentities($dom->saveXML());
 
 ## Import
 
-<p class="message-info">New feature introduced in <code>version 9.3.0</code></p>
+<p class="message-info">New feature introduced in version <code>9.3.0</code></p>
 
 ```php
 public XMLConverter::import(iterable $records, DOMDocument $doc): DOMElement
@@ -117,9 +117,9 @@ To do so, you need to specify which document the data should be imported into us
 This method takes two arguments:
 
 - the tabular data as defined for the `XMLConverter::convert` method;
-- a `DOMDocument` object to import the data into.
+- a `DOMDocument` object to import the data into;
 
-Of note the resulting `DOMElement` is attached to the given `DOMDocument` object but not yet included in the document tree.
+Note that the resulting `DOMElement` is attached to the given `DOMDocument` object but not yet included in the document tree.
 To include it, you still need to call a DOM insertion method like `appendChild` or `insertBefore` with a node that *is* currently in the document tree.
 
 ```php
@@ -131,7 +131,7 @@ $csv = Reader::createFromPath('/path/to/prenoms.csv', 'r');
 $csv->setDelimiter(';');
 $csv->setHeaderOffset(0);
 
-$stmt = (new Statement())`
+$stmt = (new Statement())
     ->where(function (array $record) {
         return 'Anaïs' === $record['prenoms'];
     })

--- a/docs/9.0/extensions/doctrine.md
+++ b/docs/9.0/extensions/doctrine.md
@@ -44,7 +44,7 @@ $result = $collection->matching($criteria);
 - **league/csv >= 9.6**
 - **doctrine/collection >= 1.6.0**
 
-but the latest stable version of each dependency is recommended.
+But the latest stable version of each dependency is recommended.
 
 ## Installation
 
@@ -79,7 +79,7 @@ $csv->setHeaderOffset(0);
 $csv->setDelimiter(';');
 
 $stmt = Statement::create()
-    ->where(fn (array $row): bool => isset($row['email']) && str_contains($row['email'], '@github.com'));
+    ->where(fn (array $row): bool => isset($row['email']) && str_ends_with($row['email'], '@github.com'));
 
 $collection = new RecordCollection($stmt->process($csv));
 ```

--- a/docs/9.0/extensions/index.md
+++ b/docs/9.0/extensions/index.md
@@ -6,10 +6,10 @@ title: League\CSV extensions
 # CSV extensions
 
 Extensions are independent packages that can be used to supercharge League\CSV.
-They are developped in sync with the main repository but are offered as stand alone package
+They are developed in sync with the main repository but are offered as standalone packages
 
 - to keep the main package slim
-- because they may require more dependencies that are not useful or needed for the core package.
+- because they may require more dependencies that are not useful or needed for the core package
 
 ## Extensions Listing
 

--- a/docs/9.0/index.md
+++ b/docs/9.0/index.md
@@ -11,7 +11,7 @@ layout: default
 [![Build](https://github.com/thephpleague/csv/workflows/build/badge.svg)](https://github.com/thephpleague/csv/actions?query=workflow%3A%22build%22)
 [![Total Downloads](//img.shields.io/packagist/dt/league/csv.svg?style=flat-square)](//packagist.org/packages/league/csv)
 
-**League\Csv** is a simple library to ease CSV documents [loading](/9.0/connections/) as well as [writing](/9.0/writer/), [selecting](/9.0/reader/) and [converting](/9.0/converter/) CSV records.
+**League\Csv** is a simple library to ease CSV document [loading](/9.0/connections/) as well as [writing](/9.0/writer/), [selecting](/9.0/reader/) and [converting](/9.0/converter/) CSV records.
 
 ## Usage
 
@@ -125,7 +125,7 @@ foreach ($csv as $record) {
 
 ### Converting a CSV document into a XML document
 
-The `XMLConverter` object provided by this package can easily convert a CSV documents into a `DOMDocument` object.
+The `XMLConverter` object provided by this package can easily convert a CSV document into a `DOMDocument` object.
 
 ```php
 use League\Csv\XMLConverter;

--- a/docs/9.0/installation.md
+++ b/docs/9.0/installation.md
@@ -32,13 +32,13 @@ composer require league/csv:^9.0
 
 You can also use `League\Csv` without using Composer by downloading the library on Github.
 
-1. Visit [the releases page](https://github.com/thephpleague/csv/releases) for the project.
-2. Find the release of `League\Csv` for your version of PHP
+1. Visit [the releases page](https://github.com/thephpleague/csv/releases) of the project.
+2. Find the release of `League\Csv` for your version of PHP.
 3. Click the **Source Code** link for preferred compression format.
 
 The library is compatible with any [PSR-4](http://www.php-fig.org/psr/psr-4/) compatible autoloader.
 
-Also, `League\Csv` comes bundle with its own autoloader script `autoload.php` located in the root directory.
+Also, `League\Csv` comes bundled with its own autoloader script `autoload.php` located in the root directory.
 
 ```php
 use League\Csv\Reader;

--- a/docs/9.0/interoperability/enclose-field.md
+++ b/docs/9.0/interoperability/enclose-field.md
@@ -5,7 +5,7 @@ title: Force Enclosure
 
 # Force field enclosure
 
-<p class="message-info">Available since <code>version 9.1.0</code></p>
+<p class="message-info">Available since version <code>9.1.0</code></p>
 
 The `EncloseField` is a PHP stream filter which forces the `Writer` class to enclose all its record fields.
 
@@ -19,8 +19,8 @@ public static EncloseField::addTo(Writer $csv, string $sequence): Writer
 
 The `EncloseField::addTo` method will:
 
-- register the stream filter if it is not already the case
-- add a formatter to the `Writer` object to force `fputcsv` to enclose all record field
+- register the stream filter if it is not already the case.
+- add a formatter to the `Writer` object to force `fputcsv` to enclose all record fields.
 - add a stream filter to the `Writer` object to remove the added sequence from the final CSV.
 
 ```php
@@ -30,7 +30,7 @@ use League\Csv\Writer;
 $writer = Writer::createFromPath('php://temp');
 EncloseField::addTo($writer, "\t\x1f"); //adding the stream filter to force enclosure
 $writer->insertAll($iterable_data);
-$writer->output('mycsvfile.csv'); //outputting a CSV Document with all its field enclosed
+$writer->output('mycsvfile.csv'); //outputting a CSV Document with all its fields enclosed
 ```
 
 <p class="message-warning">The <code>$sequence</code> argument should be a sequence containing at least one character that forces <code>fputcsv</code> to enclose the field value. If not, an <code>InvalidArgumentException</code> exception will be thrown.</p>

--- a/docs/9.0/interoperability/encoding.md
+++ b/docs/9.0/interoperability/encoding.md
@@ -11,7 +11,7 @@ Depending on the software you are using to read your CSV you may need to adjust 
 
 ## MS Excel on Windows
 
-On Windows, MS Excel, expects an UTF-8 encoded CSV with its corresponding `BOM` character. To fulfill this requirement, you simply need to add the `UTF-8` `BOM` character if needed as explained below:
+On Windows, MS Excel expects an UTF-8 encoded CSV with its corresponding `BOM` character. To fulfill this requirement, you simply need to add the `UTF-8` `BOM` character if needed as explained below:
 
 ```php
 use League\Csv\Reader;
@@ -54,4 +54,4 @@ $writer->insertAll($origin);
 $writer->output('mycsvfile.csv');
 ```
 
-<p class="message-info">The conversion is done with the <code>mb_string</code> extension using the <a href="/9.0/converter/charset/">League\Csv\CharsetConverter</a>.</p>
+<p class="message-info">The conversion is done with the <code>mbstring</code> extension using the <a href="/9.0/converter/charset/">League\Csv\CharsetConverter</a>.</p>

--- a/docs/9.0/interoperability/escape-formula-injection.md
+++ b/docs/9.0/interoperability/escape-formula-injection.md
@@ -5,11 +5,11 @@ title: CSV Formula Injection
 
 # Prevents CSV Formula Injection
 
-<p class="message-notice">Available since <code>version 9.1.0</code></p>
+<p class="message-notice">Available since version <code>9.1.0</code></p>
 
 The `EscapeFormula` Formatter formats CSV records to reduce [CSV Formula Injection](http://georgemauer.net/2017/10/07/csv-injection.html) in imported Spreadsheet programs.
 
-<p class="message-warning">since <code>version 9.7.4</code> The default values from the class constructor where updated to comply with the latest recommendations from OWASP regarding <a href="https://owasp.org/www-community/attacks/CSV_Injection" target="_blank">CSV injection</a>.
+<p class="message-warning">Since version <code>9.7.4</code> the default values from the class constructor were updated to comply with the latest recommendations from OWASP regarding <a href="https://owasp.org/www-community/attacks/CSV_Injection" target="_blank">CSV injection</a>.
 As this is a security fix, the BC break should be minimal.</p>
 
 ## Usage with Writer objects
@@ -23,8 +23,8 @@ public function __invoke(array $record): array
 
 The `EscapeFormula::__construct` method takes two (2) arguments:
 
-- the `$escape` parameter which will be used to prepend the record field, which default to `'`;
-- the `$special_chars` parameter which is an `array` with additional characters that need to be escaped. By default the following characters if found at the start of any record field content will be escaped `+`,`-`,`=`,`@`, `\t`, `\r`;
+- the `$escape` parameter which will be used to prepend the record field, which defaults to `'`;
+- the `$special_chars` parameter which is an `array` with additional characters that need to be escaped. By default, the following characters at the start of any record field content will be escaped `+`,`-`,`=`,`@`, `\t`, `\r`;
 - for more information see [OWASP - CSV Injection](https://owasp.org/www-community/attacks/CSV_Injection)
 
 ```php
@@ -53,7 +53,7 @@ foreach ($iterable_data as $record) {
 }
 ```
 
-<p class="message-warning">Even though the <code>EscapeFormula</code> formatter is provided it must stress out that
+<p class="message-warning">Even though the <code>EscapeFormula</code> formatter is provided it must be stressed that
 this is in no way a bulletproof method. This prevention mechanism only works if <strong>you know how the CSV export
-will be consumed</strong>. In any other cases, you are better of leaving the filtering to the consuming client and
-report any found security concern to their respective security channel.</p>
+will be consumed</strong>. In any other cases, you are better off leaving the filtering to the consuming client and
+report any found security concerns to their respective security channel.</p>

--- a/docs/9.0/interoperability/index.md
+++ b/docs/9.0/interoperability/index.md
@@ -5,13 +5,13 @@ title: CSV document interoperability
 
 # Document interoperability
 
-Depending on your operating system and on the software you are using to read/import your CSV you may need to adjust the CSV document:
+Depending on your operating system and software you are using to read/import your CSV, you may need to adjust the CSV document:
 
 - [encoding and BOM presence](/9.0/interoperability/encoding/)
 - [rfc4180 field compliance](/9.0/interoperability/rfc4180-field/)
 - [add the enclosure character on all fields](/9.0/interoperability/enclose-field/)
 - [prevents CSV formula injection](/9.0/interoperability/escape-formula-injection/)
 
-<p class="message-info">Out of the box, <code>League\Csv</code> connections do not alter the CSV document presentation and uses PHP's CSV native functions to read and write CSV records.</p>
+<p class="message-info">Out of the box, <code>League\Csv</code> connections do not alter the CSV document presentation and use PHP's CSV native functions to read and write CSV records.</p>
 
 In the examples we will be using an existing CSV in ISO-8859-15 charset encoding as a starting point. The code may vary if your CSV document is in a different charset and/or exposes different CSV field formats.

--- a/docs/9.0/interoperability/rfc4180-field.md
+++ b/docs/9.0/interoperability/rfc4180-field.md
@@ -5,7 +5,7 @@ title: CSV document interoperability
 
 # RFC4180 Field compliance
 
-<p class="message-warning">This class is deprecated as of version <code>9.2.0</code>. Please use directly the <code>setEscape</code> method with the empty escape character argument instead with the <code>Reader</code> or the <code>Writer</code> object.</p>
+<p class="message-warning">This class is deprecated as of version <code>9.2.0</code>. Please use the <code>setEscape</code> method directly with the empty escape character argument instead with the <code>Reader</code> or the <code>Writer</code> object.</p>
 
 The `RFC4180Field` class enables to work around the following bugs in PHP's native CSV functions:
 
@@ -45,12 +45,12 @@ $writer->output('mycsvfile.csv'); //outputting a RFC4180 compliant CSV Document
 
 When the `$whitespace_replace` sequence is different from the empty space and does not contain:
 
-- one of the current CSV control character;
-- does not contain a character that can trigger field enclosure;
+- one of the current CSV control characters;
+- a character that can trigger field enclosure;
 
 its value will be used to:
 
-- To prevent `fputcsv` default behavior of always using enclosure when a whitespace is found in a record field
+- prevent `fputcsv` default behavior of always using enclosure when a whitespace is found in a record field
 
 ```php
 use League\Csv\RFC4180Field;
@@ -69,18 +69,18 @@ use League\Csv\RFC4180Field;
 use League\Csv\Writer;
 
 $writer = Writer::createFromPath('php://temp', 'r+');
-RFC4180Field::addTo($writer, 'fo'); // incorrect sequence this will alter your CSV
+RFC4180Field::addTo($writer, 'fo'); //incorrect sequence this will alter your CSV
 $writer->insertOne(['foo bar', 'bar']);
-echo $writer->getContent(); //display ' o bar,baz' instead of foo bar,baz
+echo $writer->getContent(); //display ' o bar,baz' instead of 'foo bar,baz'
 ```
 
 ### On records insertion
 
-<p class="message-info">To fully comply with <code>RFC4180</code> you will also need to use <code>League\Csv\Writer::setNewline</code> method.</p>
+<p class="message-info">To fully comply with <code>RFC4180</code> you will also need to use <code>League\Csv\Writer::setNewline</code>.</p>
 
 ### On records extraction
 
-Conversely, to read a RFC4180 compliant CSV document, when using the `League\Csv\Reader` object, just need to add the `League\Csv\RFC4180Field` stream filter as shown below:
+Conversely, to read a RFC4180 compliant CSV document, when using the `League\Csv\Reader` object, you just need to add the `League\Csv\RFC4180Field` stream filter as shown below:
 
 ```php
 use League\Csv\Reader;
@@ -104,7 +104,7 @@ public static RFC4180Field::getFiltername(): string
 
 To use this stream filter outside `League\Csv` objects you need to:
 
-- register the stream filter using `RFC4180Field::register` method.
+- register the stream filter using `RFC4180Field::register`.
 - use `RFC4180Field::getFiltername` with one of PHP's attaching stream filter functions with the correct arguments as shown below:
 
 ```php
@@ -120,6 +120,6 @@ $filter = stream_filter_append($resource, RFC4180Field::getFiltername(), STREAM_
 ]);
 
 while (false !== ($record = fgetcsv($resource))) {
-    //$records correctly parsed
+    //$record is correctly parsed
 }
 ```

--- a/docs/9.0/reader/index.md
+++ b/docs/9.0/reader/index.md
@@ -7,7 +7,7 @@ title: CSV document Reader connection
 
 The `League\Csv\Reader` class extends the general connections [capabilities](/9.0/connections/) to ease selecting and manipulating CSV document records.
 
-<p class="message-notice">Starting with version <code>9.1.0</code>, <code>createFromPath</code> when used from the <code>Reader</code> object will have its default set to <code>r</code>.</p>
+<p class="message-notice">Starting with version <code>9.1.0</code>, <code>createFromPath</code> will have its default set to <code>r</code>.</p>
 <p class="message-notice">Prior to <code>9.1.0</code>, by default, the mode for a <code>Reader::createFromPath</code> is <code>r+</code> which looks for write permissions on the file and throws an <code>Exception</code> if the file cannot be opened with the permission set. For sake of clarity, it is strongly suggested to set <code>r</code> mode on the file to ensure it can be opened.</p>
 <p class="message-info">Starting with version <code>9.6.0</code>, the class implements the <code>League\Csv\TabularDataReader</code> interface.</p>
 <p class="message-info">Starting with version <code>9.8.0</code>, the class implements the <code>::fetchColumnByName</code> and <code>::fetchColumnByOffset</code> methods.</p>
@@ -15,7 +15,7 @@ The `League\Csv\Reader` class extends the general connections [capabilities](/9.
 
 ## CSV example
 
-Many examples in this reference require an CSV file. We will use the following file `file.csv` containing the following data:
+Many examples in this reference require a CSV file. We will use the following file `file.csv` containing the following data:
 
 ```csv
 "First Name","Last Name",E-mail
@@ -55,7 +55,7 @@ If no header offset is set:
 
 <p class="message-info">By default no header offset is set.</p>
 
-<p class="message-warning">Because the header is lazy loaded, if you provide a positive offset for an invalid record a <code>Exception</code> exception will be triggered when trying to access the invalid record.</p>
+<p class="message-warning">Because the header is lazy loaded, if you provide a positive offset for an invalid record a <code>SyntaxError</code> exception will be triggered when trying to access the invalid record.</p>
 
 ```php
 use League\Csv\Reader;
@@ -63,20 +63,20 @@ use League\Csv\Reader;
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
 $csv->setHeaderOffset(1000); //valid offset but the CSV does not contain 1000 records
 $header_offset = $csv->getHeaderOffset(); //returns 1000
-$header = $csv->getHeader(); //triggers a Exception exception
+$header = $csv->getHeader(); //throws a SyntaxError exception
 ```
 
-Because the csv document is treated as a tabular data the header can not contain duplicate entries.
+Because the csv document is treated as tabular data the header can not contain duplicate entries.
 If the header contains duplicates an exception will be thrown on usage.
 
 ```php
 use League\Csv\Reader;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
-$csv->fetchOne(0); // returns ['field1', 'field2', 'field1', 'field4']
+$csv->fetchOne(0); //returns ['field1', 'field2', 'field1', 'field4']
 $csv->setHeaderOffset(0); //valid offset but the record contain duplicates
 $header_offset = $csv->getHeaderOffset(); //returns 0
-$header = $csv->getHeader(); //triggers a Exception exception
+$header = $csv->getHeader(); //throws a SyntaxError exception
 ```
 
 <p class="message-info">Starting with <code>9.7.0</code> the <code>SyntaxError</code> exception thrown will return the list of duplicate column names.</p>
@@ -86,13 +86,13 @@ use League\Csv\Reader;
 use League\Csv\SyntaxError;
 
 $csv = Reader::createFromPath('/path/to/file.csv', 'r');
-$csv->fetchOne(0); // returns ['field1', 'field2', 'field1', 'field4']
+$csv->fetchOne(0); //returns ['field1', 'field2', 'field1', 'field4']
 $csv->setHeaderOffset(0); //valid offset but the record contain duplicates
 $header_offset = $csv->getHeaderOffset(); //returns 0
 try {
-    $header = $csv->getHeader(); //triggers a Exception exception
+    $header = $csv->getHeader(); //throws a SyntaxError exception
 } catch (SyntaxError $exception) {
-   $duplicates = $exception->duplicateColumnNames(); // returns ['field1']
+    $duplicates = $exception->duplicateColumnNames(); //returns ['field1']
 }
 ```
 
@@ -104,7 +104,7 @@ public Reader::getRecords(array $header = []): Iterator
 
 ### Reader::getRecords basic usage
 
-The `Reader` class let's you access all its records using the `Reader::getRecords` method.
+The `Reader` class lets you access all its records using the `Reader::getRecords` method.
 The method returns an `Iterator` containing all CSV document records. It will extract the records using the [CSV controls characters](/9.0/connections/controls/);
 
 ```php
@@ -120,13 +120,12 @@ foreach ($records as $offset => $record) {
     //  'doe',
     //  'john.doe@example.com'
     // );
-    //
 }
 ```
 
 ### Reader::getRecords with Reader::setHeaderOffset
 
-If you specify the CSV header offset using `setHeaderOffset`, the found record will be combined to each CSV record to return an associated array whose keys are composed of the header values.
+If you specify the CSV header offset using `setHeaderOffset`, the found record will be combined to each CSV record to return an associative array whose keys are composed of the header values.
 
 ```php
 use League\Csv\Reader;
@@ -142,7 +141,6 @@ foreach ($records as $offset => $record) {
     //  'Last Name' => 'doe',
     //  'E-mail' => 'jane.doe@example.com'
     // );
-    //
 }
 ```
 
@@ -159,7 +157,7 @@ foreach ($records as $offset => $record) {
     //$offset : represents the record offset
     //var_export($record) returns something like
     // array(
-    //  'firstame' => 'jane',
+    //  'firstname' => 'jane',
     //  'lastname' => 'doe',
     //  'email' => 'jane.doe@example.com'
     // );
@@ -178,15 +176,15 @@ foreach ($records as $offset => $record) {
     //$offset : represents the record offset
     //var_export($record) returns something like
     // array(
-    //  'firstame' => 'jane',
+    //  'firstname' => 'jane',
     //  'lastname' => 'doe',
     //  'email' => 'jane.doe@example.com'
     // );
 }
-//the first record will still be skip!!
+//the first record will still be skipped!!
 ```
 
-<p class="message-warning">In both cases, if the header record contains non unique string values, a <code>Exception</code> exception is triggered.</p>
+<p class="message-warning">In both cases, if the header record contains non-unique string values, a <code>Exception</code> exception is triggered.</p>
 
 ### Using the IteratorAggregate interface
 
@@ -206,7 +204,6 @@ foreach ($reader as $offset => $record) {
     //  'Last Name' => 'doe',
     //  'E-mail' => john.doe@example.com'
     // );
-    //
 }
 ```
 
@@ -214,9 +211,9 @@ foreach ($reader as $offset => $record) {
 
 The returned records are normalized using the following rules:
 
-- [Stream filters](/9.0/connections/filters/) are applied if present
-- Empty records are skipped if present;
-- The document BOM sequence is skipped if present;
+- [Stream filters](/9.0/connections/filters/) are applied if present.
+- Empty records are skipped if present.
+- The document BOM sequence is skipped if present.
 - If a header record was provided, the number of fields is normalized to the number of fields contained in that record:
   - Extra fields are truncated.
   - Missing fields are added with a `null` value.
@@ -235,7 +232,6 @@ foreach ($records as $offset => $record) {
     //  'Last Name' => 'jane',
     //  'E-mail' => null
     // );
-    //
 }
 ```
 
@@ -243,7 +239,7 @@ foreach ($records as $offset => $record) {
 
 <p class="message-info">New since version <code>9.4.0</code></p>
 
-By default the CSV document normalization removes empty records. But you can control the presence of such records using the following methods:
+By default, the CSV document normalization removes empty records, but you can control the presence of such records using the following methods:
 
 ```php
 Reader::skipEmptyRecords(): self;
@@ -253,11 +249,10 @@ Reader::isEmptyRecordsIncluded(): bool;
 
 - Calling `Reader::includeEmptyRecords` will ensure empty records are left in the `Iterator` returned by `Reader::getRecords`,
 conversely `Reader::skipEmptyRecords` will ensure empty records are skipped.
-- At any given time you can ask you Reader instance if empty records will be stripped or included using the `Reader::isEmptyRecordsIncluded` method.
-- If no header offset is specified, the empty record will be represented by a empty `array`, conversely,
-for consistency, an empty record will be represented by an array filled with `null` values as expected from header presence normalization.
+- At any given time you can ask your Reader instance if empty records will be stripped or included using the `Reader::isEmptyRecordsIncluded` method.
+- If no header offset is specified, the empty record will be represented by an empty `array`. Conversely, for consistency, an empty record will be represented by an array filled with `null` values as expected from header presence normalization.
 
-<p class="message-notice">The record offset are always independent of the presence of empty records.</p>
+<p class="message-notice">The record offset is always independent of the presence of empty records.</p>
 
 ```php
 use League\Csv\Reader;
@@ -270,7 +265,7 @@ $source = <<<EOF
 EOF;
 
 $reader = Reader::createFromString($source);
-$reader->isEmptyRecordsIncluded(); // return true;
+$reader->isEmptyRecordsIncluded(); //returns false
 iterator_to_array($reader, true);
 // [
 //     0 => ['parent name', 'child name', 'title'],
@@ -278,7 +273,7 @@ iterator_to_array($reader, true);
 // ];
 
 $reader->includeEmptyRecords();
-$reader->isEmptyRecordsIncluded(); // return false;
+$reader->isEmptyRecordsIncluded(); //returns true
 iterator_to_array($reader, true);
 // [
 //     0 => ['parent name', 'child name', 'title'],
@@ -296,7 +291,7 @@ iterator_to_array($reader, true);
 // ];
 
 $reader->skipEmptyRecords();
-$reader->isEmptyRecordsIncluded(); // return false;
+$reader->isEmptyRecordsIncluded(); //returns false
 $res = iterator_to_array($reader, true);
 // [
 //     3 => ['parent name' => 'parentA', 'child name' => 'childA', 'title' => 'titleA'],
@@ -305,7 +300,7 @@ $res = iterator_to_array($reader, true);
 
 ## Records count
 
-You can retrieve the number of records contains in a CSV document using PHP's `count` function because the `Reader` class implements the `Countable` interface.
+You can retrieve the number of records contained in a CSV document using PHP's `count` function because the `Reader` class implements the `Countable` interface.
 
 ```php
 use League\Csv\Reader;
@@ -326,18 +321,18 @@ count($reader); //returns 3
 
 <p class="message-info">New since version <code>9.4.0</code></p>
 
-If empty record are to be preserved, the number of records will be affected.
+If empty records are to be preserved, the number of records will be affected.
 
 ```php
 use League\Csv\Reader;
 
 $reader = Reader::createFromPath('/path/to/my/file-with-two-empty-records.csv', 'r');
 $reader->isEmptyRecordsIncluded(); //returns false
-count($reader); // returns 2
+count($reader); //returns 2
 
 $reader->includeEmptyRecords();
 $reader->isEmptyRecordsIncluded(); //returns true
-count($reader); // returns 4
+count($reader); //returns 4
 ```
 
 <p class="message-notice">The <code>Countable</code> interface is implemented using PHP's <code>iterator_count</code> on the <code>Reader::getRecords</code> method.</p>
@@ -398,8 +393,7 @@ public Writer::addFormatter(callable $callable): Reader
 public Writer::addHeaderFormatter(callable $callable): Reader
 ```
 
-Sometimes you may want to format your records prior to accessing them via `getRecords`. the `Reader` class provides
-a formatter mechanism to ease these operations.
+Sometimes you may want to format your records prior to accessing them via `getRecords`. The `Reader` class provides a formatter mechanism to ease these operations.
 
 ## Records conversion
 

--- a/docs/9.0/reader/resultset.md
+++ b/docs/9.0/reader/resultset.md
@@ -10,7 +10,7 @@ A `League\Csv\ResultSet` object represents the associated result set of processi
 <p class="message-info">Starting with version <code>9.6.0</code>, the class implements the <code>League\Csv\TabularDataReader</code> interface.</p>
 <p class="message-info">Starting with version <code>9.8.0</code>, the class implements the <code>::fetchColumnByName</code> and <code>::fetchColumnByOffset</code> methods.</p>
 
-## Informations
+## Information
 
 ### Accessing the result set column names
 
@@ -28,7 +28,7 @@ use League\Csv\Statement;
 
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $records = Statement::create()->process($reader);
-$records->getHeader(); // is empty because no header information was given
+$records->getHeader(); //is empty because no header information was given
 ```
 
 #### Example: header information given by the Reader object
@@ -40,7 +40,7 @@ $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 
 $records = Statement::create()->process($reader);
-$records->getHeader(); // returns ['First Name', 'Last Name', 'E-mail'];
+$records->getHeader(); //returns ['First Name', 'Last Name', 'E-mail'];
 ```
 
 #### Example: header information given by the Statement object
@@ -53,12 +53,12 @@ $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
 $reader->setHeaderOffset(0);
 
 $records = Statement::create()->process($reader, ['Prénom', 'Nom', 'E-mail']);
-$records->getHeader(); // returns ['Prénom', 'Nom', 'E-mail'];
+$records->getHeader(); //returns ['Prénom', 'Nom', 'E-mail'];
 ```
 
 ### Accessing the number of records in the result set
 
-The `ResultSet` class implements implements the `Countable` interface.
+The `ResultSet` class implements the `Countable` interface.
 
 ```php
 use League\Csv\Reader;
@@ -77,9 +77,9 @@ count($records); //return the total number of records found
 public ResultSet::getRecords(array $header = []): Iterator
 ```
 
-<p class="message-info">Starting with version <code>9.6.0</code>, the class implements the <code>ResultSet::getRecords</code> methods matches the same arguments and the same signature as the <code>Reader::getRecords</code> method.</p>
+<p class="message-info">Starting with version <code>9.6.0</code>, the implemented <code>ResultSet::getRecords</code> method matches the same arguments and the same signature as the <code>Reader::getRecords</code> method.</p>
 
-To iterate over each found records you can call the `ResultSet::getRecords` method which returns a `Generator` of all records found or directly use the `foreach` construct as the class implements the `IteratorAggregate` interface;
+To iterate over each found record you can call the `ResultSet::getRecords` method which returns a `Generator` of all records found or directly use the `foreach` construct as the class implements the `IteratorAggregate` interface:
 
 ```php
 use League\Csv\Reader;
@@ -99,7 +99,7 @@ foreach ($records as $record) {
 
 ### Usage with the header
 
-If the `ResultSet::getHeader` is not an empty `array` the found records keys will contains the method returned values.
+If the `ResultSet::getHeader` is not an empty `array` the found records keys will contain the returned values.
 
 ```php
 use League\Csv\Reader;
@@ -110,20 +110,19 @@ $reader->setHeaderOffset(0);
 $records = Statement::create()->process($reader);
 $records->getHeader(); //returns ['First Name', 'Last Name', 'E-mail']
 foreach ($records as $record) {
-    // $records contains the following data
+    // $record contains the following data
     // array(
     //     'First Name' => 'john',
     //     'Last Name' => 'doe',
     //     'E-mail' => 'john.doe@example.com',
     // );
-    //
 }
 ```
 
 ## Selecting a specific record
 
-Since with version <code>9.9.0</code>, the class implements the `::first` and `::nth` methods.
-These methods replace the `::fetchOne` which is deprecated and will be removed in the next major release.
+Since version <code>9.9.0</code>, the class implements the `::first` and `::nth` methods.
+These methods replace the `::fetchOne` method which is deprecated and will be removed in the next major release.
 
 These methods all return a single record from the `ResultSet`.
 
@@ -136,7 +135,7 @@ public ResultSet::nth(int $nth_record): array
 The `$nth_record` argument represents the nth record contained in the result set starting at `0`.  
 In the case of `fetchOne`, if no argument is given the method will return the first record from the result set.
 
-In all cases, if no record is found an empty `array` is returned.
+In all cases, if no record is found, an empty `array` is returned.
 
 ```php
 use League\Csv\Reader;
@@ -165,7 +164,7 @@ $result->nth(0);
 //returns the first matching record from the recordset or an empty record if none is found.
 ```
 
-<p class="message-notice"><code>nth</code> with throw a <code>ArgumentCountError</code>, if no argument is given to it.</p>
+<p class="message-notice"><code>nth</code> will throw an <code>ArgumentCountError</code> if no argument is given to it.</p>
 
 ## Selecting a single column
 
@@ -175,13 +174,12 @@ public ResultSet::fetchColumnByOffset(int $offset = 0): Iterator
 public ResultSet::fetchColumn(string|int $columnIndex = 0): Iterator
 ```
 
-Since with version <code>9.8.0</code>, the class implements the `::fetchColumnByName` and `::fetchColumnByOffset` methods.
-These methods replace the `::fetchColumn` which is deprecated and will be removed in the next major release.
+Since version <code>9.8.0</code>, the class implements the `::fetchColumnByName` and `::fetchColumnByOffset` methods.
+These methods replace the `::fetchColumn` method which is deprecated and will be removed in the next major release.
 
-Both methods return a `Iterator` of all values in a given column from the `ResultSet` object. But they differ
-in their argument type:
+Both methods return an `Iterator` of all values in a given column from the `ResultSet` object, but they differ in their argument type:
 
-`::fetchColumnByName` expects a string representing one of the value of `ResultSet::getHeader`
+`::fetchColumnByName` expects a string representing one of the values of `ResultSet::getHeader`
 
 ```php
 $reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
@@ -194,7 +192,7 @@ foreach ($records->fetchColumnByName('E-mail') as $value) {
 }
 ```
 
-<p class="message-warning">If the <code>ResultSet</code> contains column names and the <code>$name</code> is not found an <code>Exception</code> exception is thrown.</p>
+<p class="message-warning">If the <code>ResultSet</code> contains column names and the <code>$name</code> is not found, an <code>Exception</code> exception is thrown.</p>
 
 ```php
 use League\Csv\Reader;
@@ -239,12 +237,12 @@ count(iterator_to_array($records->fetchColumnByOffset(2), false)); //returns 5
 //5 records were skipped because the column value is null
 ```
 
-<p class="message-warning">The following paragraph describe the usage of the <code>::fetchColumn</code> method which is
-deprecated as of <code>9.8.0</code> and which wil be removed in the next major release.</p>
+<p class="message-warning">The following paragraph describes the usage of the <code>::fetchColumn</code> method which is
+deprecated as of <code>9.8.0</code> and wil be removed in the next major release.</p>
 
 `ResultSet::fetchColumn` returns a `Generator` of all values in a given column from the `ResultSet` object.
 
-the `$columnIndex` parameter can be:
+The `$columnIndex` parameter can be:
 
 - an integer representing the column index starting from `0`;
 - a string representing one of the value of `ResultSet::getHeader`;
@@ -283,7 +281,7 @@ count(iterator_to_array($records->fetchColumn(2), false)); //returns 5
 //5 records were skipped because the column value is null
 ```
 
-<p class="message-warning">If the <code>ResultSet</code> contains column names and the <code>$columnIndex</code> is not found an <code>Exception</code> exception is thrown.</p>
+<p class="message-warning">If the <code>ResultSet</code> contains column names and the <code>$columnIndex</code> is not found, an <code>Exception</code> exception is thrown.</p>
 
 ```php
 use League\Csv\Reader;
@@ -317,44 +315,42 @@ These arguments behave exactly like the `$columnIndex` from `ResultSet::fetchCol
 
 ```php
 use League\Csv\Reader;
+use League\Csv\Statement;
 
-$str = <<EOF
+$str = <<<EOF
 john,doe
 jane,doe
 foo,bar
 sacha
 EOF;
 
-use League\Csv\Reader;
-use League\Csv\Statement;
-
 $reader = Reader::createFromString($str);
 $records = Statement::create()->process($reader);
 
 foreach ($records->fetchPairs() as $firstname => $lastname) {
     // - first iteration
-    // echo $firstname; -> 'john'
-    // echo $lastname;  -> 'doe'
+    // $firstname -> 'john'
+    // $lastname  -> 'doe'
     // - second iteration
-    // echo $firstname; -> 'jane'
-    // echo $lastname;  -> 'doe'
+    // $firstname -> 'jane'
+    // $lastname  -> 'doe'
     // - third iteration
-    // echo $firstname; -> 'foo'
-    // echo $lastname; -> 'bar'
+    // $firstname -> 'foo'
+    // $lastname  -> 'bar'
     // - fourth iteration
-    // echo $firstname; -> 'sacha'
-    // echo $lastname; -> 'null'
+    // $firstname -> 'sacha'
+    // $lastname  -> null
 }
 ```
 
 ### Notes
 
-- If no `$offsetIndex` is provided it default to `0`;
-- If no `$valueIndex` is provided it default to `1`;
+- If no `$offsetIndex` is provided it defaults to `0`;
+- If no `$valueIndex` is provided it defaults to `1`;
 - If no cell is found corresponding to `$offsetIndex` the row is skipped;
 - If no cell is found corresponding to `$valueIndex` the `null` value is used;
 
-<p class="message-warning">If the <code>ResultSet</code> contains column names and the submitted arguments are not found an <code>Exception</code> exception is thrown.</p>
+<p class="message-warning">If the <code>ResultSet</code> contains column names and the submitted arguments are not found, an <code>Exception</code> exception is thrown.</p>
 
 ## Conversions
 

--- a/docs/9.0/reader/statement.md
+++ b/docs/9.0/reader/statement.md
@@ -9,13 +9,13 @@ The `League\Csv\Statement` class is a constraint builder to help ease selecting 
 
 When building a constraint, the methods do not need to be called in any particular order, and may be called multiple times. Because the `Statement` object is immutable, each time its constraint methods are called they will return a new `Statement` object without modifying the current `Statement` object.
 
-<p class="message-info">Because the <code>Statement</code> object is independent of the <code>Reader</code> object it can be re-use on multiple <code>Reader</code> objects.</p>
+<p class="message-info">Because the <code>Statement</code> object is independent of the <code>Reader</code> object it can be re-used on multiple <code>Reader</code> objects.</p>
 
 <p class="message-info">Starting with version <code>9.6.0</code>, the class exposes the <code>Statement::create</code> named constructor to ease object creation.</p>
 
 ## Filtering constraint
 
-The filters attached using the `Statement::where` method **are the first settings applied to the CSV before anything else**. This option follow the *First In First Out* rule.
+The filters attached using the `Statement::where` method **are the first settings applied to the CSV before anything else**. This option follows the *First In First Out* rule.
 
 ```php
 public Statement::where(callable $callable): self
@@ -29,16 +29,15 @@ function(array $record [, int $offset [, Iterator $iterator]]): self
 
 It takes up to three parameters:
 
-- `$record`: the CSV current record as an array
-- `$offset`: the CSV current record offset
+- `$record`: the current CSV record as an array
+- `$offset`: the current CSV record offset
 - `$iterator`: the current CSV iterator
 
 ## Sorting constraint
 
 The sorting options are applied **after the Statement::where options**. The sorting follows the *First In First Out* rule.
 
-<p class="message-warning"><strong>Warning:</strong> To sort the data <code>iterator_to_array</code> is used, which could lead to a performance penalty if you have a heavy CSV file to sort
-</p>
+<p class="message-warning"><strong>Warning:</strong> To sort the data <code>iterator_to_array</code> is used, which could lead to a performance penalty if you have a heavy CSV file to sort</p>
 
 `Statement::orderBy` method adds a sorting function each time it is called.
 
@@ -56,20 +55,20 @@ The sort function takes exactly two parameters, which will be filled by pairs of
 
 ## Interval constraint
 
-The interval methods enable returning a specific interval of CSV records. When called more than once, only the last filtering settings is taken into account. The interval is calculated **after applying Statement::orderBy options**.
+The interval methods enable returning a specific interval of CSV records. When called more than once, only the last filtering setting is taken into account. The interval is calculated **after applying Statement::orderBy options**.
 
-The interval API is made of the following method
+The interval API is made of the following methods:
 
 ```php
 public Statement::offset(int $offset): self
 public Statement::limit(int $limit): self
 ```
 
-`Statement::offset` specifies an optional offset for the return data. By default if no offset was provided the offset equals `0`.
+`Statement::offset` specifies an optional offset for the returned data. By default, if no offset is provided the offset equals `0`.
 
-`Statement::limit` specifies an optional maximum records count for the return data. By default if no limit is provided the limit equals `-1`, which translate to all records.
+`Statement::limit` specifies an optional maximum records count for the returned data. By default, if no limit is provided the limit equals `-1`, which translates to all records.
 
-<p class="message-notice">When called multiple times, each call override the last settings for these options.</p>
+<p class="message-notice">When called multiple times, each call overrides the last setting for these options.</p>
 
 ## Processing a CSV document
 
@@ -104,7 +103,7 @@ $stmt = (new Statement())
 $records = $stmt->process($reader);
 ```
 
-Just like the `Reader:getRecords`, the `Statement::process` method takes an optional `$header` argument to allow mapping CSV fields name to user defined header record.
+Just like the `Reader:getRecords`, the `Statement::process` method takes an optional `$header` argument to allow mapping CSV field names to a user defined header record.
 
 ```php
 use League\Csv\Reader;
@@ -137,5 +136,5 @@ $resultSet = $stmt->process($reader, ['firstname', 'lastname', 'email']);
 
 $stmt2 = Statement::create(null, 3, 2);
 $records = $stmt2->process($resultSet);
-// the $records and the $resultSet parameters are distinct League\Csv\ResultSet instances.
+//the $records and $resultSet variables are distinct League\Csv\ResultSet instances.
 ```

--- a/docs/9.0/upgrading.md
+++ b/docs/9.0/upgrading.md
@@ -8,7 +8,7 @@ redirect_from: /upgrading/9.0/
 
 `League\Csv 9.0` is a new major version that comes with backward compatibility breaks.
 
-This guide will help you migrate from a 8.x version to 9.0. It will only explain backward compatibility breaks, it will not present the new features ([read the documentation for that](/9.0/)).
+This guide will help you migrate from a 8.x version to 9.0. It will only explain backward compatibility breaks, it will not present the new features, ([read the documentation for that](/9.0/)).
 
 ## Installation
 
@@ -22,7 +22,7 @@ This will edit (or create) your `composer.json` file.
 
 ## PHP version requirement
 
-`League\Csv 9.0` requires a PHP version greater or equal than 7.0.0 (was previously 5.5.0).
+`League\Csv 9.0` requires a PHP version greater or equal to 7.0.0 (was previously 5.5.0).
 
 <p class="message-warning">The library is not tested on <code>HHVM</code></p>
 
@@ -30,7 +30,7 @@ This will edit (or create) your `composer.json` file.
 
 ### Stricter argument type
 
-The `Writer::insertOne` and `Writer::insertAll` methods no longer accept string as possible CSV records
+The `Writer::insertOne` and `Writer::insertAll` methods no longer accept a string as possible CSV records.
 
 Before:
 
@@ -193,7 +193,7 @@ $records = $stmt->process($reader, ['firstname', 'lastname', 'email']);
 
 #### Reader::fetchAll, Reader::fetch, Reader::each
 
-Theses methods are removed because the `Reader` and the `ResultSet` implements the `IteratorAggregate` interface
+These methods are removed because the `Reader` and the `ResultSet` implements the `IteratorAggregate` interface.
 
 Before:
 
@@ -321,7 +321,7 @@ $stats = delimiter_detect($reader, [',', ';', "\t"], 10);
 
 ### Optional callable arguments are removed
 
-The following methods no longer accept an optional callable as argument because they return a iterable object.
+The following methods no longer accept an optional callable as argument because they return an iterable object.
 
 - `Reader::fetchColumn`
 - `Reader::fetchPairs`
@@ -345,7 +345,7 @@ use League\Csv\Reader;
 $reader = Reader::createFromPath('/path/to/file.csv', 'r');
 foreach ($records->fetchColumn(0) as $value) {
     $value = strtoupper($value);
-};
+}
 ```
 
 ## Stream Filtering
@@ -433,7 +433,7 @@ $csv = null;
 
 ## Conversion methods
 
-All convertion methods are no longer attached to the `Reader` or the `Writer` classes you need a [Converter](/9.0/reader/converter/) object to convert your CSV. The following methods are removed
+All conversion methods are no longer attached to the `Reader` or the `Writer` classes, you need a [Converter](/9.0/reader/converter/) object to convert your CSV. The following methods are removed:
 
 - `Writer::jsonSerialize`
 - `AbstractCsv::toHTML`
@@ -467,7 +467,7 @@ $dom = (new XMLConverter())->convert($csv); //$dom is a DOMDocument
 - `AbstractCsv::newReader`
 - `AbstractCsv::newWriter`
 
-You can no longer switch between connection. You are require to explicitly load a new `Reader` and/or `Writer` object.
+You can no longer switch between connection. You are required to explicitly load a new `Reader` and/or `Writer` object.
 
 ### Columns consistency Validator
 

--- a/docs/9.0/writer/helpers.md
+++ b/docs/9.0/writer/helpers.md
@@ -9,15 +9,14 @@ title: Bundled Writer helpers
 
 The `League\Csv\ColumnConsistency` class validates the inserted record column count consistency.
 
-This class constructor accepts a single argument `$column_count` which sets the column count value and validate each record length against the given value. If the value differs an `CannotInsertRecord` will be thrown.
+This class constructor accepts a single argument `$column_count` which sets the column count value and validates each record length against the given value. If the value differs, a `CannotInsertRecord` exception will be thrown.
 
-if `$column_count` equals `-1`, the object will lazy set the column count value according to the next inserted record and therefore will also validate it. On the next insert, if the given value differs a `CannotInsertRecord` exception is triggered.
+If `$column_count` equals `-1`, the object will lazy set the column count value according to the next inserted record and therefore will also validate it. On the next insert, if the given value differs, a `CannotInsertRecord` exception is triggered.
 At any given time you can retrieve the column count value using the `ColumnConsistency::getColumnCount` method.
 
 ```php
 use League\Csv\Writer;
 use League\Csv\ColumnConsistency;
-
 
 $validator = new ColumnConsistency();
 $writer = Writer::createFromPath('/path/to/your/csv/file.csv');
@@ -48,7 +47,7 @@ $writer->insertOne(["foo", "bébé", "jouet"]);
 //all 'utf-8' characters are now automatically encoded into 'iso-8859-15' charset
 ```
 
-If your `Writer` object supports PHP stream filters then it's recommended to use the `CharsetConverter` object via the library [stream filtering mechanism](/9.0/connections/filters/) instead as shown below.
+If your `Writer` object supports PHP stream filters then it's recommended to use the `CharsetConverter` object via the library [stream filtering mechanism](/9.0/connections/filters/) instead, as shown below:
 
 ```php
 use League\Csv\CharsetConverter;

--- a/docs/9.0/writer/index.md
+++ b/docs/9.0/writer/index.md
@@ -16,7 +16,7 @@ public Writer::insertOne(array $record): int
 public Writer::insertAll(iterable $records): int
 ```
 
-`Writer::insertOne` inserts a single record into the CSV document while `Writer::insertAll` adds several records. Both methods returns the length of the written data.
+`Writer::insertOne` inserts a single record into the CSV document while `Writer::insertAll` adds several records. Both methods return the length of the written data.
 
 `Writer::insertOne` takes a single argument, an `array` which represents a single CSV record.
 `Writer::insertAll` takes a single argument a PHP iterable which contains a collection of CSV records.
@@ -95,19 +95,19 @@ public Writer::getNewline(void): string
 use League\Csv\Writer;
 
 $writer = Writer::createFromFileObject(new SplFileObject());
-$newline = $writer->getNewline(); // equals "\n";
+$newline = $writer->getNewline(); //equals "\n";
 $writer->setNewline("\r\n");
-$newline = $writer->getNewline(); // equals "\r\n";
+$newline = $writer->getNewline(); //equals "\r\n";
 $writer->insertOne(["one", "two"]);
-echo $writer->getContent(); // displays "one,two\r\n";
+echo $writer->getContent(); //displays "one,two\r\n";
 ```
 
 <p class="message-info">The default newline sequence is <code>\n</code>;</p>
-<p class="message-warning">If you are using a non seekable CSV document, changing the newline character will trigger an exception.</p>
+<p class="message-warning">If you are using a non-seekable CSV document, changing the newline character will trigger an exception.</p>
 
 ## Flushing the buffer
 
-For advanced usages, you can now manually indicates when flushing mechanism occurs while adding new content to your CSV document.
+For advanced usages, you can now manually indicate when the flushing mechanism occurs while adding new content to your CSV document.
 
 ### Description
 
@@ -118,7 +118,7 @@ public Writer::getFlushThreshold(void): ?int
 
 By default, `getFlushTreshold` returns `null`.
 
-<p class="message-info"><code>Writer::insertAll</code> always flush its buffer when all records are inserted regardless of the threshold value.</p>
+<p class="message-info"><code>Writer::insertAll</code> always flushes its buffer when all records are inserted, regardless of the threshold value.</p>
 
 <p class="message-info">If set to <code>null</code> the inner flush mechanism of PHP's <code>fputcsv</code> will be used.</p>
 
@@ -129,13 +129,13 @@ public Writer::addFormatter(callable $callable): Writer
 public Writer::addValidator(callable $callable, string $validatorName): Writer
 ```
 
-Sometimes you may want to format and/or validate your records prior to their insertion into your CSV document. the `Writer` class provides a formatter and a validator mechanism to ease these operations.
+Sometimes you may want to format and/or validate your records prior to their insertion into your CSV document. The `Writer` class provides a formatter and a validator mechanism to ease these operations.
 
 ### Writer::addFormatter
 
 #### Record Formatter
 
-A formatter is a `callable` which accepts an single CSV record as an `array` on input and returns an array representing the formatted CSV record according to its inner rules.
+A formatter is a `callable` which accepts a single CSV record as an `array` on input and returns an array representing the formatted CSV record according to its inner rules.
 
 ```php
 function(array $record): array
@@ -155,15 +155,15 @@ $writer = Writer::createFromFileObject(new SplTempFileObject());
 $writer->addFormatter($formatter);
 $writer->insertOne(['john', 'doe', 'john.doe@example.com']);
 
-$writer->getContent();
-//will display something like JOHN,DOE,JOHN.DOE@EXAMPLE.COM
+echo $writer->getContent();
+//will display JOHN,DOE,JOHN.DOE@EXAMPLE.COM
 ```
 
 ### Writer::addValidator
 
 #### Record Validator
 
-A validator is a `callable` which takes single CSV record as an `array` as its sole argument and returns a `boolean` to indicate if it satisfies the validator inner rules.
+A validator is a `callable` which takes a single CSV record as an `array` as its sole argument and returns a `boolean` to indicate if it satisfies the validator's inner rules.
 
 ```php
 function(array $record): bool
@@ -171,7 +171,7 @@ function(array $record): bool
 
 The validator **must** return `true` to validate the submitted record.
 
-Any other expression, including truthy ones like `yes`, `1`,... will make the `insertOne` method throw an `League\Csv\CannotInsertRecord`.
+Any other expression, including truthy ones like `yes`, `1`,... will make the `insertOne` method throw an `League\Csv\CannotInsertRecord` exception.
 
 #### Adding a Validator to a Writer object
 
@@ -201,7 +201,7 @@ $writer->addValidator(function (array $row): bool {
 try {
     $writer->insertOne(['john', 'doe', 'john.doe@example.com']);
 } catch (CannotInsertRecord $e) {
-    echo $e->getName(); //display 'row_must_contain_10_cells'
-    $e->getData();//will return the invalid data ['john', 'doe', 'john.doe@example.com']
+    echo $e->getName(); //displays 'row_must_contain_10_cells'
+    $e->getData();//returns the invalid data ['john', 'doe', 'john.doe@example.com']
 }
 ```

--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -7,7 +7,7 @@ version:
         Connections Settings:
             Overview: '/9.0/connections/'
             Document Loading: '/9.0/connections/instantiation/'
-            Characters Controls: '/9.0/connections/controls/'
+            Character Controls: '/9.0/connections/controls/'
             BOM Sequences: '/9.0/connections/bom/'
             Stream Filters: '/9.0/connections/filters/'
             Document output: '/9.0/connections/output/'

--- a/docs/_data/project.yml
+++ b/docs/_data/project.yml
@@ -1,7 +1,7 @@
 # Documentation website
 title: CSV
 tagline: "CSV data manipulation made easy in PHP."
-description: "Working with CSV can often be much more difficult than you expect, with different types of delimiter and complicated structures. This makes it easy to read and write almost anything."
+description: "Working with CSV can often be much more difficult than you expect, with different types of delimiters and complicated structures. This library makes it easy to read and write almost anything."
 google_analytics_tracking_id: UA-46050814-6
 # Github repository
 repository: 'csv'
@@ -37,7 +37,7 @@ author:
     github_account: 'nyamsprod'
 # Homepage specific
 highlights:
-  description: 'The library was designed for developers who want to deal with CSV data using modern code and without the high levels of bootstrap and low-levels of usefulness provided by existing core functions or third party-code.'
+  description: 'The library was designed for developers who want to deal with CSV data using modern code and without the high levels of bootstrap and low-levels of usefulness provided by existing core functions or third-party code.'
   features:
       - 'Simple API'
       - 'Read and Write to CSV documents in a memory efficient and scalable way'
@@ -45,4 +45,4 @@ highlights:
       - 'Transform CSV documents into popular formats (JSON, XML or HTML)'
       - 'Framework-agnostic'
 composer: '$ composer require league/csv'
-support: 'Once a new major version is released, the previous stable release remains supported for six more months through patches and security fixes.'
+support: 'Once a new major version is released, the previous stable release remains supported for six more months with patches and security fixes.'

--- a/docs/upgrading/6.0.md
+++ b/docs/upgrading/6.0.md
@@ -79,9 +79,9 @@ if (! $delimiters_list) {
 
 ### Transcoding Charset Property
 
-`setEncoding`/`getEnconding`: the `$encondingFrom` property setter and getter are renamed `setEncodingFrom`/`getEncondingFrom` to avoid any ambiguity.
+`setEncoding`/`getEncoding`: the `$encodingFrom` property setter and getter are renamed `setEncodingFrom`/`getEncodingFrom` to avoid any ambiguity.
 
-**The library always assume that the output is in `UTF-8`** so when transcoding your CSV you should always transcode from the `$encondingFrom` charset into an UTF-8 compatible charset.
+**The library always assumes that the output is in `UTF-8`** so when transcoding your CSV you should always transcode from the `$encodingFrom` charset into an UTF-8 compatible charset.
 
 You need to upgrade your code accordingly.
 

--- a/src/InvalidArgument.php
+++ b/src/InvalidArgument.php
@@ -52,7 +52,7 @@ class InvalidArgument extends Exception
 
     public static function dueToInvalidEscapeCharacter(string $escape, string $method): self
     {
-        return new self($method.'() expects escape to be a single character or the empty string; `'.$escape.'` given.');
+        return new self($method.'() expects escape to be a single character or an empty string; `'.$escape.'` given.');
     }
 
     public static function dueToInvalidColumnCount(int $columns_count, string $method): self

--- a/src/RFC4180Field.php
+++ b/src/RFC4180Field.php
@@ -90,7 +90,7 @@ class RFC4180Field extends php_user_filter
     public static function addFormatterTo(Writer $csv, string $whitespace_replace): Writer
     {
         if ('' == $whitespace_replace || strlen($whitespace_replace) !== strcspn($whitespace_replace, self::$force_enclosure)) {
-            throw new InvalidArgumentException('The sequence contains a character that enforces enclosure or is a CSV control character or is the empty string.');
+            throw new InvalidArgumentException('The sequence contains a character that enforces enclosure or is a CSV control character or is an empty string.');
         }
 
         $mapper = fn ($value) => is_string($value)


### PR DESCRIPTION
> "Extraordinary packages require Extraordinary proofing" - me

My thanks to this lovely package :smiling_face_with_three_hearts: 

This PR fixes:
- typos
- grammar
- code examples
- certain consistency

This is an initial proofing of the most obvious things and doesn't aim for *full* consistency, which could be worked towards if desired.
<details>
  <summary>For example</summary>

- "trigger" vs. "throw" when talking about exceptions
- reference exception classes directly without the redundant "exception" (e.g. throws an `Exception` exception)
- consist end characters for list items (i.e. some end in ".", some with ";", some nothing at all)

</details>