### PR TITLE
Fix wrong documentation

### DIFF
--- a/docs/9.0/reader/index.md
+++ b/docs/9.0/reader/index.md
@@ -384,17 +384,6 @@ $records = $stmt->process($reader);
 //$records is a League\Csv\ResultSet object
 ```
 
-## Records formatting
-
-<p class="message-info">New since version <code>9.9.0</code></p>
-
-```php
-public Writer::addFormatter(callable $callable): Reader
-public Writer::addHeaderFormatter(callable $callable): Reader
-```
-
-Sometimes you may want to format your records prior to accessing them via `getRecords`. The `Reader` class provides a formatter mechanism to ease these operations.
-
 ## Records conversion
 
 ### Json serialization


### PR DESCRIPTION
The `Reader` class does not provide any formatting feature, since it has been removed in commit 607c140d760c73907ce5fc82200b9a2f9dba1f24.

Also, note that the class name (`Writer`) was wrong anyway.