### PR TITLE
Adding collections methods to the TabularReader interface

### DIFF
--- a/docs/9.0/reader/index.md
+++ b/docs/9.0/reader/index.md
@@ -459,7 +459,7 @@ $records = $reader->filter(fn (array $record): => 5 === count($record));
 #### Reader::slice
 
 Extracts a slice of $length elements starting at position $offset from the Collection.
-If $length is `-1` it returns all elements from `$offset` to the end of the 
+If $length is `-1` it returns all elements from `$offset` to the end of the
 Collection. Keys have to be preserved by this method. Calling this
 method will only return the selected slice and NOT change the
 elements contained in the collection slice is called on.

--- a/docs/9.0/reader/index.md
+++ b/docs/9.0/reader/index.md
@@ -388,7 +388,7 @@ $records = $stmt->process($reader);
 
 <p class="message-notice">New methods added in version <code>9.11</code>.</p>
 
-To ease working with the loaded CSV document the following methods derived from collection are added. 
+To ease working with the loaded CSV document the following methods derived from collection are added.
 Some are just wrapper methods around the `Statement` class while others use the iterable nature
 of the CSV document.
 
@@ -458,10 +458,14 @@ $records = $reader->filter(fn (array $record): => 5 === count($record));
 
 #### Reader::slice
 
-Extracts a slice of $length elements starting at position $offset from the Collection. If $length is `-1` it returns all elements from `$offset` to the end of the Collection. 
-Keys have to be preserved by this method. Calling this method will only return the selected slice and NOT change the elements contained in the collection slice is called on.
+Extracts a slice of $length elements starting at position $offset from the Collection.
+If $length is `-1` it returns all elements from `$offset` to the end of the 
+Collection. Keys have to be preserved by this method. Calling this
+method will only return the selected slice and NOT change the
+elements contained in the collection slice is called on.
 
-<p class="message-info"> Wraps the functionality of <code>Statement::offset</code> and <code>Statement::limit</code>.</p>
+<p class="message-info"> Wraps the functionality of <code>Statement::offset</code>
+and <code>Statement::limit</code>.</p>
 
 ```php
 use League\Csv\Reader;

--- a/docs/9.0/reader/index.md
+++ b/docs/9.0/reader/index.md
@@ -384,6 +384,110 @@ $records = $stmt->process($reader);
 //$records is a League\Csv\ResultSet object
 ```
 
+### Collection methods
+
+<p class="message-notice">New methods added in version <code>9.11</code>.</p>
+
+To ease working with the loaded CSV document the following methods derived from collection are added. 
+Some are just wrapper methods around the `Statement` class while others use the iterable nature
+of the CSV document.
+
+#### Reader::each
+
+Iterates over the records in the CSV document and passes each item to a closure:
+
+```php
+use League\Csv\Reader;
+use League\Csv\Writer;
+
+$writer = Writer::createFromString('');
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$reader->each(function (array $record, int $offset) use ($writer) {
+     if ($offset < 10) {
+        return $writer->insertOne($record);
+     }
+     
+     return false;
+});
+
+//$writer will contain at most 10 lines coming from the $reader document.
+// the iteration stopped when the closure return false.
+```
+
+#### Reader::exists
+
+Tests for the existence of an element that satisfies the given predicate.
+
+```php
+use League\Csv\Reader;
+
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$exists = $reader->exists(fn (array $records) => in_array('twenty-five', $records, true));
+
+//$exists returns true if at cell one cell contains the word `twenty-five` otherwise returns false,
+```
+
+#### Reader::reduce
+
+Applies iteratively the given function to each element in the collection, so as to reduce the collection to
+a single value.
+
+```php
+use League\Csv\Reader;
+
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$nbTotalCells = $reader->recude(fn (?int $carry, array $records) => ($carry ?? 0) + count($records));
+
+//$records contains the total number of celle contains in the CSV documents.
+```
+
+#### Reader::filter
+
+Returns all the elements of this collection for which your callback function returns `true`. The order and keys of the elements are preserved.
+
+<p class="message-info"> Wraps the functionality of <code>Statement::where</code>.</p>
+
+```php
+use League\Csv\Reader;
+
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$records = $reader->filter(fn (array $record): => 5 === count($record));
+
+//$recors is a ResultSet object with only records with 5 elements
+```
+
+#### Reader::slice
+
+Extracts a slice of $length elements starting at position $offset from the Collection. If $length is `-1` it returns all elements from `$offset` to the end of the Collection. 
+Keys have to be preserved by this method. Calling this method will only return the selected slice and NOT change the elements contained in the collection slice is called on.
+
+<p class="message-info"> Wraps the functionality of <code>Statement::offset</code> and <code>Statement::limit</code>.</p>
+
+```php
+use League\Csv\Reader;
+
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$records = $reader->slice(10, 25);
+
+//$records contains up to 25 rows starting at the offest 10 (the eleventh rows)
+```
+
+#### Reader::sorted
+
+Sorts the CSV document while keeping the original keys.
+
+```php
+use League\Csv\Reader;
+
+$reader = Reader::createFromPath('/path/to/my/file.csv', 'r');
+$records = $reader->sorted(fn (array $recordA, array $recordB) => $recordA['firstname'] <=> $recordB['firstname']);
+
+//$records is a ResultSet containing the sorted CSV document. 
+//The original $reader is not changed
+```
+
+<p class="message-info"> Wraps the functionality of <code>Statement::orderBy</code>.</p>
+
 ## Records conversion
 
 ### Json serialization

--- a/src/TabularDataReader.php
+++ b/src/TabularDataReader.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\Csv;
 
+use Closure;
 use Countable;
 use Iterator;
 use IteratorAggregate;
@@ -24,6 +25,12 @@ use IteratorAggregate;
  * @method Iterator fetchColumnByOffset(int $offset) returns a column from its offset
  * @method array first() returns the first record from the tabular data.
  * @method array nth(int $nth_record) returns the nth record from the tabular data.
+ * @method bool each(Closure $closure) iterates over each record and passes it to a closure. Iteration is interrupted if the closure returns false
+ * @method bool exists(Closure $closure) tells whether at least one record satisfies the predicate.
+ * @method mixed reduce(Closure $closure, mixed $initial = null) reduces the collection to a single value, passing the result of each iteration into the subsequent iteration
+ * @method TabularDataReader filter(Closure $closure) returns all the elements of this collection for which your callback function returns `true`
+ * @method TabularDataReader slice(int $offset, int $length = null) extracts a slice of $length elements starting at position $offset from the Collection.
+ * @method TabularDataReader sorted(Closure $orderBy) sorts the Collection according to the closure provided see Statement::orderBy method
  */
 interface TabularDataReader extends Countable, IteratorAggregate
 {


### PR DESCRIPTION
The following collection methods are added

- [X] `each`
- [X] `exists`
- [X] `reduce`
- [X] `filter`
- [X] `sorted`
- [X] `slice` 

