### PR TITLE
Docs: Fix `fetchColumnByOffset` example

### DIFF
--- a/docs/9.0/reader/tabular-data-reader.md
+++ b/docs/9.0/reader/tabular-data-reader.md
@@ -162,7 +162,7 @@ header offset.
 $reader = Reader::createFromPath('/path/to/my/file.csv');
 $reader->setHeaderOffset(0);
 $records = Statement::create()->process($reader);
-foreach ($records->fetchColumnByName(3) as $value) {
+foreach ($records->fetchColumnByOffset(3) as $value) {
     //$value is a string representing the value
     //of a given record for the selected column
     //$value may be equal to 'john.doe@example.com'


### PR DESCRIPTION
Fix the `fetchColumnByOffset` example in docs by changing from `fetchColumnByName` to `fetchColumnByOffset`.