### PR TITLE
Explicitly mark nullable parameter

### DIFF
--- a/src/TabularDataReader.php
+++ b/src/TabularDataReader.php
@@ -34,7 +34,7 @@ use IteratorAggregate;
  * @method Iterator getObjects(string $className, array $header = []) Returns the tabular data records as an iterator object containing instance of the defined class name.
  * @method Iterator getRecordsAsObject(string $className, array $header = []) Returns the tabular data records as an iterator object containing instance of the defined class name.
  * @method TabularDataReader filter(Query\Predicate|Closure $predicate) returns all the elements of this collection for which your callback function returns `true`
- * @method TabularDataReader slice(int $offset, int $length = null) extracts a slice of $length elements starting at position $offset from the Collection.
+ * @method TabularDataReader slice(int $offset, ?int $length = null) extracts a slice of $length elements starting at position $offset from the Collection.
  * @method TabularDataReader sorted(Query\Sort|Closure $orderBy) sorts the Collection according to the closure provided see Statement::orderBy method
  * @method TabularDataReader select(string|int ...$columnOffsetOrName) extract a selection of the tabular data records columns.
  * @method TabularDataReader matchingFirstOrFail(string $expression) extract the first found fragment identifier of the tabular data or fail


### PR DESCRIPTION
Implicitly nullable parameter declarations are deprecated in PHP 8.4. The proposed change is safe and is not considered by PHP as a signature change, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated