### PR TITLE
Fix usage of non empty `$escape` in PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All Notable changes to `Csv` will be documented in this file
 
+## [Next] - TBD
+
+### Added
+
+- `League\Csv\Fragment\Expression`
+- `League\Csv\Fragment\Selection` (internal class)
+
+### Deprecated
+
+- `League\Csv\FragmentFinder::findAll` use `League\Csv\Fragment\Expression::fragment` instead
+
+### Fixed
+
+- `Cast*` methods accept more input type.
+- `FragmentFinder` now removes duplicate selection.
+- `TabularaDataReader::matching` will return an empty `Iterable` instance when no selection is valid, previously and empty `TabularDataReader` instance was returned as unique item of the iterable returned.
+
+### Removed
+
+- None
+
 ## [9.16.0](https://github.com/thephpleague/csv/compare/9.15.0...9.16.0) - 2024-05-24
 
 ### Added

--- a/docs/9.0/reader/tabular-data-reader.md
+++ b/docs/9.0/reader/tabular-data-reader.md
@@ -506,6 +506,7 @@ $reader->matchingFirstOrFail('row=3-1;4-6'); // will throw
 
 <p class="message-info"> Wraps the functionality of <code>FragmentFinder</code> class.</p>
 <p class="message-notice">Added in version <code>9.12.0</code> for <code>Reader</code> and <code>ResultSet</code>.</p>
+<p class="message-info">In addition to using a string expression, starting with version <code>9.17.0</code> you can alternatively use an `Expression` object.</p>
 
 ### chunkBy
 

--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -44,8 +44,8 @@ abstract class AbstractCsv implements ByteSequence
     protected ?Bom $input_bom = null;
     protected ?Bom $output_bom = null;
     protected string $delimiter = ',';
-    protected string $enclosure = '"';
-    protected string $escape = '\\';
+    protected string $enclosure = '\\';
+    protected string $escape = '';
     protected bool $is_input_bom_included = false;
 
     /**

--- a/src/Fragment/Expression.php
+++ b/src/Fragment/Expression.php
@@ -13,34 +13,84 @@ declare(strict_types=1);
 
 namespace League\Csv\Fragment;
 
+use Countable;
+use IteratorAggregate;
+use League\Csv\Exception;
 use League\Csv\FragmentNotFound;
-use function preg_match;
-use function explode;
-use function array_map;
+use League\Csv\InvalidArgument;
+use League\Csv\Statement;
+use League\Csv\SyntaxError;
+use League\Csv\TabularDataReader;
+use ReflectionException;
+use Stringable;
+use Traversable;
 
-final class Expression
+use function array_map;
+use function explode;
+use function implode;
+use function preg_match;
+
+/**
+ * @implements IteratorAggregate<int, string>
+ */
+final class Expression implements Stringable, Countable, IteratorAggregate
 {
     private const REGEXP_URI_FRAGMENT = ',^(?<type>row|cell|col)=(?<selections>.*)$,i';
 
+    private readonly Type $type;
     /** @param array<Selection> $selections */
-    private function __construct(
-        public readonly Type $type,
-        public readonly array $selections
-    ) {}
+    private readonly array $selections;
 
-    public static function tryFrom(string $expression): self
+    /**
+     * @param array<Selection> $selections
+     */
+    private function __construct(Type $type, array $selections)
     {
-        try {
-            return self::from($expression);
-        } catch (FragmentNotFound $fragmentNotFound) {
-            return self::fromUnknown();
-        }
+        $this->type = $type;
+        $this->selections = self::removeDuplicates($selections);
     }
 
-    public static function from(string $expression): self
+    /**
+     * @param array<Selection|null> $selections
+     *
+     * @return array<Selection>
+     */
+    private static function removeDuplicates(array $selections): array
     {
-        if (1 !== preg_match(self::REGEXP_URI_FRAGMENT, $expression, $matches)) {
-            throw new FragmentNotFound('The submitted expression `'.$expression.'` is invalid.');
+        $sorted = [];
+        foreach ($selections as $selection) {
+            if (null !== $selection) {
+                $sorted[$selection->toString()] = $selection;
+            }
+        }
+
+        return array_values($sorted);
+    }
+
+    /**
+     * @param array<Selection> $selections1
+     * @param array<Selection> $selections2
+     */
+    private static function isEqualSelection(array $selections1, array $selections2): bool
+    {
+        $toString = static fn (Selection $selection): string => $selection->toString();
+        $selectionsA = array_map($toString, $selections1);
+        $selectionsB = array_map($toString, $selections2);
+
+        sort($selectionsA);
+        sort($selectionsB);
+
+        return $selectionsB === $selectionsA;
+    }
+
+    public static function from(Stringable|string $expression): self
+    {
+        if ($expression instanceof self) {
+            return $expression;
+        }
+
+        if (1 !== preg_match(self::REGEXP_URI_FRAGMENT, (string) $expression, $matches)) {
+            throw new FragmentNotFound('The expression "' . $expression . '" does not match the CSV fragment Identifier specification.');
         }
 
         $selections = explode(';', $matches['selections']);
@@ -49,27 +99,336 @@ final class Expression
             Type::Row => self::fromRow(...$selections),
             Type::Column => self::fromColumn(...$selections),
             Type::Cell => self::fromCell(...$selections),
-            default => throw new FragmentNotFound('The submitted expression `'.$expression.'` is invalid.'),
         };
-    }
-
-    public static function fromUnknown(): self
-    {
-        return new self(Type::Unknown, [Selection::fromUnknown()]);
     }
 
     public static function fromCell(string ...$selections): self
     {
-        return new self(Type::Cell, array_map(Selection::fromCell(...), $selections));
+        return new self(Type::Cell, array_filter(array_map(Selection::fromCell(...), $selections)));
     }
 
     public static function fromColumn(string ...$selections): self
     {
-        return new self(Type::Column, array_map(Selection::fromColumn(...), $selections));
+        return new self(Type::Column, array_filter(array_map(Selection::fromColumn(...), $selections)));
     }
 
     public static function fromRow(string ...$selections): self
     {
-        return new self(Type::Row, array_map(Selection::fromRow(...), $selections));
+        return new self(Type::Row, array_filter(array_map(Selection::fromRow(...), $selections)));
+    }
+
+    public function type(): Type
+    {
+        return $this->type;
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->selections;
+    }
+
+    public function isNotEmpty(): bool
+    {
+        return ! $this->isEmpty();
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    public function toString(): string
+    {
+        return $this->type->value .'='.implode(
+            ';',
+            array_map(fn (Selection $selection): string => $selection->toString(), $this->selections)
+        );
+    }
+
+    public function count(): int
+    {
+        return count($this->selections);
+    }
+
+    public function getIterator(): Traversable
+    {
+        foreach ($this->selections as $selection) {
+            yield $selection->toString();
+        }
+    }
+
+    public function get(int $key): string
+    {
+        return $this->selections[
+            $this->filterIndex($key) ?? throw new FragmentNotFound('No selection found for the given key `'.$key.'`.')
+        ]->toString();
+    }
+
+    public function hasKey(int ...$keys): bool
+    {
+        $max = count($this->selections);
+        foreach ($keys as $offset) {
+            if (null === $this->filterIndex($offset, $max)) {
+                return false;
+            }
+        }
+
+        return [] !== $keys;
+    }
+
+    public function has(string ...$selections): bool
+    {
+        foreach ($selections as $selection) {
+            if (null === $this->contains($selection)) {
+                return false;
+            }
+        }
+
+        return [] !== $selections;
+    }
+
+    public function contains(string $selection): ?int
+    {
+        if ([] === $this->selections) {
+            return null;
+        }
+
+        $selection = (match ($this->type) {
+            Type::Row => Selection::fromRow($selection),
+            Type::Column => Selection::fromColumn($selection),
+            Type::Cell => Selection::fromCell($selection),
+        })?->toString();
+
+        if (null === $selection) {
+            return null;
+        }
+
+        foreach ($this->selections as $offset => $innerSelection) {
+            if ($selection === $innerSelection->toString()) {
+                return $offset;
+            }
+        }
+
+        return null;
+    }
+
+    private function filterIndex(int $index, ?int $max = null): ?int
+    {
+        $max ??= count($this->selections);
+
+        return match (true) {
+            [] === $this->selections, 0 > $max + $index, 0 > $max - $index - 1 => null,
+            0 > $index => $max + $index,
+            default => $index,
+        };
+    }
+
+    public function push(string ...$selections): self
+    {
+        if ([] === $selections) {
+            return $this;
+        }
+
+        $selections = array_filter(match ($this->type) {
+            Type::Row => array_map(Selection::fromRow(...), $selections),
+            Type::Column => array_map(Selection::fromColumn(...), $selections),
+            Type::Cell => array_map(Selection::fromCell(...), $selections),
+        });
+
+        $selections = self::removeDuplicates($selections);
+        if ([] === $selections || self::isEqualSelection($this->selections, $selections)) {
+            return $this;
+        }
+
+        return new self($this->type, [...$this->selections, ...$selections]);
+    }
+
+    public function unshift(string ...$selections): self
+    {
+        if ([] === $selections) {
+            return $this;
+        }
+
+        $selections = array_filter(match ($this->type) {
+            Type::Row => array_map(Selection::fromRow(...), $selections),
+            Type::Column => array_map(Selection::fromColumn(...), $selections),
+            Type::Cell => array_map(Selection::fromCell(...), $selections),
+        });
+
+        $selections = self::removeDuplicates($selections);
+        if ([] === $selections || self::isEqualSelection($this->selections, $selections)) {
+            return $this;
+        }
+
+        return new self($this->type, [...$selections, ...$this->selections]);
+    }
+
+    public function replace(string $oldSelection, string $newSelection): self
+    {
+        $offset = $this->contains($oldSelection);
+        if (null === $offset) {
+            throw new FragmentNotFound('The selection `'.$oldSelection.'` used for replace is not valid');
+        }
+
+        $newSelectionObject = match ($this->type) {
+            Type::Row => Selection::fromRow($newSelection),
+            Type::Column => Selection::fromColumn($newSelection),
+            Type::Cell => Selection::fromCell($newSelection),
+        };
+
+        if (null === $newSelectionObject) {
+            throw new FragmentNotFound('The selection `'.$newSelection.'` used for replace is not valid');
+        }
+
+        if (null === $this->contains($newSelectionObject->toString())) {
+            return $this;
+        }
+
+        return match ($newSelectionObject->toString()) {
+            $oldSelection => $this,
+            default => new self($this->type, array_replace($this->selections, [$offset => $newSelectionObject])),
+        };
+    }
+
+    public function remove(string ...$selections): self
+    {
+        if (in_array([], [$this->selections, $selections], true)) {
+            return $this;
+        }
+
+        $keys = array_filter(array_map($this->contains(...), $selections), fn (int|null $key): bool => null !== $key);
+
+        return match (true) {
+            [] === $keys => $this,
+            count($keys) === count($this->selections) => new self($this->type, []),
+            default => new self($this->type, array_values(
+                array_filter(
+                    $this->selections,
+                    fn (int $key): bool => !in_array($key, $keys, true),
+                    ARRAY_FILTER_USE_KEY
+                )
+            )),
+        };
+    }
+
+    /**
+     * @throws Exception
+     * @throws InvalidArgument
+     * @throws ReflectionException
+     * @throws SyntaxError
+     */
+    public function firstFragment(TabularDataReader $tabularDataReader): ?TabularDataReader
+    {
+        foreach ($this->fragment($tabularDataReader) as $tabularData) {
+            return $tabularData;
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws Exception
+     * @throws InvalidArgument
+     * @throws ReflectionException
+     * @throws SyntaxError
+     *
+     * @return iterable<string, TabularDataReader>
+     */
+    public function fragment(TabularDataReader $tabularDataReader): iterable
+    {
+        $statements = [] === $this->selections ? [] : match ($this->type) {
+            Type::Row => $this->queryByRows(),
+            Type::Column => $this->queryByColumns($tabularDataReader),
+            Type::Cell => $this->queryByCells($tabularDataReader),
+        };
+
+        foreach ($statements as $selection => $statement) {
+            yield $selection => $statement->process($tabularDataReader);
+        }
+    }
+
+    /**
+     * @throws Exception
+     * @throws InvalidArgument
+     * @throws SyntaxError
+     * @throws ReflectionException
+     *
+     * @return iterable<string, Statement>
+     */
+    private function queryByRows(): iterable
+    {
+        $predicate = fn (array $record, int $offset): bool => [] !== array_filter(
+            $this->selections,
+            fn (Selection $selection): bool => $offset >= $selection->rowStart &&
+                (null === $selection->rowEnd || $offset <= $selection->rowEnd)
+        );
+
+        yield $this->toString() => Statement::create()->where($predicate);
+    }
+
+    /**
+     * @throws Exception
+     * @throws InvalidArgument
+     * @throws ReflectionException
+     * @throws SyntaxError
+     *
+     * @return iterable<string, Statement>
+     */
+    private function queryByColumns(TabularDataReader $tabularDataReader): iterable
+    {
+        $nbColumns = $this->getTabularDataColumnCount($tabularDataReader);
+        $columns = array_reduce(
+            $this->selections,
+            fn (array $columns, Selection $selection): array => [
+                ...$columns,
+                ...match (($columnRange = $selection->columnRange())) {
+                    null => range($selection->columnStart, $nbColumns - 1),
+                    default => $selection->columnEnd > $nbColumns || $selection->columnEnd === -1 ? range($selection->columnStart, $nbColumns - 1) : $columnRange,
+                }
+            ],
+            []
+        );
+
+        if ([] !== $columns) {
+            yield $this->toString() => Statement::create()->select(...$columns);
+        }
+    }
+
+    /**
+     * @throws Exception
+     * @throws InvalidArgument
+     * @throws ReflectionException
+     * @throws SyntaxError
+     *
+     * @return iterable<string, Statement>
+     */
+    private function queryByCells(TabularDataReader $tabularDataReader): iterable
+    {
+        $nbColumns = $this->getTabularDataColumnCount($tabularDataReader);
+        $mapper = fn (Selection $selection): Statement => Statement::create()
+            ->where(
+                fn (array $record, int $offset): bool => $offset >= $selection->rowStart &&
+                    (null === $selection->rowEnd || $offset <= $selection->rowEnd)
+            )
+            ->select(
+                ...match (($columnRange = $selection->columnRange())) {
+                    null => range($selection->columnStart, $nbColumns - 1),
+                    default => $selection->columnEnd > $nbColumns || $selection->columnEnd === -1 ? range($selection->columnStart, $nbColumns - 1) : $columnRange,
+                }
+            );
+
+        foreach ($this->selections as $selection) {
+            yield Type::Cell->value.'='.$selection->toString() => $mapper($selection);
+        }
+    }
+
+    private function getTabularDataColumnCount(TabularDataReader $tabularDataReader): int
+    {
+        $header = $tabularDataReader->getHeader();
+
+        return count(match ($header) {
+            [] => $tabularDataReader->first(),
+            default => $header,
+        });
     }
 }

--- a/src/Fragment/ExpressionTest.php
+++ b/src/Fragment/ExpressionTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * League.Csv (https://csv.thephpleague.com)
+ *
+ * (c) Ignace Nyamagana Butera <nyamsprod@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace League\Csv\Fragment;
+
+use League\Csv\FragmentNotFound;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ExpressionTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('validExpressionProvider')]
+    public function it_can_generate_an_expression_from_a_string(string $input, string $expected): void
+    {
+        self::assertSame($expected, Expression::from($input)->toString());
+    }
+
+    public static function validExpressionProvider(): iterable
+    {
+        yield 'single row' => [
+            'input' => 'ROW=1',
+            'expected' => 'row=1',
+        ];
+
+        yield 'row range' => [
+            'input' => 'row=1-5',
+            'expected' => 'row=1-5',
+        ];
+
+        yield 'row infinite range' => [
+            'input' => 'row=12-*',
+            'expected' => 'row=12-*',
+        ];
+
+        yield 'multiple row selections' => [
+            'input' => 'row=1-5;12-*',
+            'expected' => 'row=1-5;12-*',
+        ];
+
+        yield 'single column' => [
+            'input' => 'CoL=1',
+            'expected' => 'col=1',
+        ];
+
+        yield 'column range' => [
+            'input' => 'col=12-24',
+            'expected' => 'col=12-24',
+        ];
+
+        yield 'column infinite range' => [
+            'input' => 'col=12-*',
+            'expected' => 'col=12-*',
+        ];
+
+        yield 'multiple column selections' => [
+            'input' => 'col=1-5;12-*',
+            'expected' => 'col=1-5;12-*',
+        ];
+
+        yield 'single cell' => [
+            'input' => 'CeLl=1,4',
+            'expected' => 'cell=1,4',
+        ];
+
+        yield 'cell range' => [
+            'input' => 'CeLl=1,4-5,9',
+            'expected' => 'cell=1,4-5,9',
+        ];
+
+        yield 'cell range with infinite' => [
+            'input' => 'CeLl=1,4-*',
+            'expected' => 'cell=1,4-*',
+        ];
+
+        yield 'multiple cell selection' => [
+            'input' => 'CeLl=1,4-5,9;12,15-*',
+            'expected' => 'cell=1,4-5,9;12,15-*',
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('invalidExpressionProvider')]
+    public function it_will_throw_parsing_incorrect_expression(string $expression): void
+    {
+        $this->expectException(FragmentNotFound::class);
+
+        Expression::from($expression)->toString();
+    }
+
+    public static function invalidExpressionProvider(): iterable
+    {
+        yield 'invalid row index' => ['expression' => 'row=-1'];
+        yield 'invalid row end' => ['expression' => 'row=1--1'];
+        yield 'invalid row number' => ['expression' => 'row=1-four'];
+        yield 'invalid row range infinite' => ['expression' => 'row=*-1'];
+        yield 'invalid multiple row range' => ['expression' => 'row=1-4,2-5'];
+
+        yield 'invalid column index' => ['expression' => 'col=-1'];
+        yield 'invalid column end' => ['expression' => 'col=1--1'];
+        yield 'invalid column number' => ['expression' => 'col=1-four'];
+        yield 'invalid column range infinite' => ['expression' => 'col=*-1'];
+        yield 'invalid multiple column range' => ['expression' => 'col=1-4,2-5'];
+
+        yield 'invalid cell' => ['expression' => 'cell=1,*'];
+        yield 'invalid cell index' => ['expression' => 'cell=1,-3'];
+        yield 'invalid cell number' => ['expression' => 'cell=1,three'];
+    }
+
+    #[Test]
+    #[DataProvider('ignoreExpressionProvider')]
+    public function it_will_fail_parsing_incorrect_expression(string $expression): void
+    {
+        $this->expectException(FragmentNotFound::class);
+
+        Expression::from($expression);
+    }
+
+    public static function ignoreExpressionProvider(): iterable
+    {
+        yield 'invalid multiple cell selection' => ['expression' => 'cell=2,3-14,16;22-23'];
+    }
+
+    #[Test]
+    public function it_can_add_remove_selections(): void
+    {
+        $expression = Expression::fromColumn();
+        self::assertCount(0, $expression);
+
+        $addExpression = $expression
+            ->push( '12-*')
+            ->unshift('1-5');
+
+        $removeExpression = $addExpression->remove('12-*');
+        $replaceExpression = $addExpression->replace('12-*', '8-9');
+
+        self::assertCount(0, $expression);
+        self::assertCount(2, $addExpression);
+        self::assertCount(2, $replaceExpression);
+        self::assertCount(1, $removeExpression);
+        self::assertSame($addExpression->get(-1), $replaceExpression->get(-1));
+
+        self::assertSame($expression, $expression->push());
+        self::assertSame($expression, $expression->unshift());
+        self::assertSame($expression, $expression->remove());
+        self::assertFalse($expression->has('12-*'));
+
+        self::assertSame($addExpression, $addExpression->push());
+        self::assertSame($addExpression, $addExpression->unshift());
+        self::assertSame($addExpression, $addExpression->remove());
+        self::assertSame($addExpression, $addExpression->replace($addExpression->get(0), $addExpression->get(0)));
+
+        self::assertEquals('12-*', $addExpression->get(1));
+        self::assertEquals('12-*', $addExpression->get(-1));
+        self::assertTrue($addExpression->has('12-*'));
+
+        self::assertFalse($removeExpression->hasKey(1));
+        self::assertFalse($removeExpression->has('12-*'));
+        self::assertTrue($removeExpression->hasKey(0));
+        self::assertEquals('1-5', $removeExpression->get(0));
+        self::assertEquals('1-5', $addExpression->get(0));
+
+        $this->expectException(FragmentNotFound::class);
+        $removeExpression->get(42);
+    }
+
+    #[Test]
+    public function it_can_ignore_all_selections(): void
+    {
+        self::assertSame('row=', Expression::fromRow('7-5')->toString());
+        self::assertSame('row=', Expression::fromRow()->toString());
+        self::assertSame('row=', Expression::from('row=')->toString());
+        self::assertTrue(Expression::from('row=')->isEmpty());
+        self::assertSame(Type::Row, Expression::from('row=')->type());
+
+        self::assertSame('cell=', Expression::fromCell('2,3-1,2')->toString());
+        self::assertSame('cell=', Expression::fromCell()->toString());
+        self::assertSame('cell=', Expression::from('cell=')->toString());
+        self::assertSame(Type::Cell, Expression::from('cell=')->type());
+
+        self::assertSame('col=', Expression::fromColumn('7-5')->toString());
+        self::assertSame('col=', Expression::fromColumn()->toString());
+        self::assertSame('col=', Expression::from('col=')->toString());
+        self::assertSame(Type::Column, Expression::from('col=')->type());
+
+    }
+}

--- a/src/Fragment/Selection.php
+++ b/src/Fragment/Selection.php
@@ -16,6 +16,9 @@ namespace League\Csv\Fragment;
 use League\Csv\FragmentNotFound;
 use const FILTER_VALIDATE_INT;
 
+/**
+ * @internal Internal representation of an Expression Selection.
+ */
 final class Selection
 {
     private const REGEXP_ROWS_COLUMNS_SELECTION = '/^(?<start>\d+)(-(?<end>\d+|\*))?$/';
@@ -29,59 +32,79 @@ final class Selection
         )?
     $/x';
 
-    public static function fromUnknown(): self
-    {
-        return new self(-1, null, -1, null);
-    }
-
     private function __construct(
         public readonly int $rowStart,
         public readonly ?int $rowEnd,
         public readonly int $columnStart,
         public readonly ?int $columnEnd,
-    ) {
-    }
+    ) {}
 
-    public function rowCount(): ?int
-    {
-        return match (true) {
-            -1 === $this->rowStart => null,
-            null === $this->rowEnd => -1,
-            default => $this->rowEnd - $this->rowStart + 1,
-        };
-    }
-
-    public function columnRange(): ?array
-    {
-        return match (true) {
-            -1 === $this->columnStart => [],
-            null === $this->columnEnd => null,
-            default => range($this->columnStart, $this->columnEnd),
-        };
-    }
-
-    public static function fromRow(string $selection): self
+    public static function fromRow(string $selection): ?self
     {
         [$start, $end] = self::parseRowColumnSelection($selection);
 
         return match (true) {
-            -1 === $start => throw new FragmentNotFound('The submitted selection `'.$selection.'` is invalid.'),
+            -1 === $start => null,
             null === $end => new self($start, $start, -1, null),
             '*' === $end => new self($start, null, -1, null),
             default => new self($start, $end,-1, null),
         };
     }
 
-    public static function fromColumn(string $selection): self
+    public static function fromColumn(string $selection): ?self
     {
         [$start, $end] = self::parseRowColumnSelection($selection);
 
         return match (true) {
-            -1 === $start => throw new FragmentNotFound('The submitted selection `'.$selection.'` is invalid.'),
+            -1 === $start => null,
             null === $end => new self(-1, null, $start, $start),
             '*' === $end => new self(-1, null, $start, -1),
             default => new self(-1, null, $start, $end),
         };
+    }
+
+    public static function fromCell(string $selection): ?self
+    {
+        if ('' === $selection) {
+            return new self(-1, -1, -1, -1);
+        }
+
+        if (1 !== preg_match(self::REGEXP_CELLS_SELECTION, $selection, $found)) {
+            return throw new FragmentNotFound('The fragment selection "'.$selection.'" is invalid.');
+        }
+
+        $cellStartRow = filter_var($found['csr'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        $cellStartCol = filter_var($found['csc'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        if (false === $cellStartRow || false === $cellStartCol) {
+            return null;
+        }
+
+        --$cellStartRow;
+        --$cellStartCol;
+
+        $cellEnd = $found['end'] ?? null;
+        if (null === $cellEnd) {
+            return new self($cellStartRow, $cellStartRow, $cellStartCol, $cellStartCol);
+        }
+
+        if ('*' === $cellEnd) {
+            return new self($cellStartRow, null, $cellStartCol, -1);
+        }
+
+        $cellEndRow = filter_var($found['cer'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        $cellEndCol = filter_var($found['cec'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        if (false === $cellEndRow || false === $cellEndCol) {
+            return null;
+        }
+
+        --$cellEndRow;
+        --$cellEndCol;
+
+        if ($cellEndRow < $cellStartRow || $cellEndCol < $cellStartCol) {
+            return null;
+        }
+
+        return new self($cellStartRow, $cellEndRow, $cellStartCol, $cellEndCol,);
     }
 
     /**
@@ -89,8 +112,12 @@ final class Selection
      */
     private static function parseRowColumnSelection(string $selection): array
     {
-        if (1 !== preg_match(self::REGEXP_ROWS_COLUMNS_SELECTION, $selection, $found)) {
+        if ('' === $selection) {
             return [-1, 0];
+        }
+
+        if (1 !== preg_match(self::REGEXP_ROWS_COLUMNS_SELECTION, $selection, $found)) {
+            throw new FragmentNotFound('The fragment selection "'.$selection.'" is invalid.');
         }
 
         $start = $found['start'];
@@ -118,43 +145,43 @@ final class Selection
         return [$start, $end];
     }
 
-    public static function fromCell(string $selection): self
+    public function toString(): string
     {
-        if (1 !== preg_match(self::REGEXP_CELLS_SELECTION, $selection, $found)) {
-            throw new FragmentNotFound('The submitted selection `'.$selection.'` is invalid.');
+        if (-1 === $this->columnStart && -1 === $this->rowStart) {
+            return '';
         }
 
-        $cellStartRow = filter_var($found['csr'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
-        $cellStartCol = filter_var($found['csc'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
-        if (false === $cellStartRow || false === $cellStartCol) {
-            throw new FragmentNotFound('The submitted selection `'.$selection.'` is invalid.');
+        if (-1 === $this->columnStart) {
+            return (string) match ($this->rowEnd) {
+                null => ($this->rowStart + 1).'-*',
+                $this->rowStart => ($this->rowStart + 1),
+                default => ($this->rowStart + 1).'-'.($this->rowEnd + 1),
+            };
         }
 
-        --$cellStartRow;
-        --$cellStartCol;
-
-        $cellEnd = $found['end'] ?? null;
-        if (null === $cellEnd) {
-            return new self($cellStartRow, $cellStartRow, $cellStartCol, $cellStartCol);
+        if (-1 === $this->rowStart) {
+            return (string) match ($this->columnEnd) {
+                -1 => ($this->columnStart + 1).'-*',
+                null, $this->columnStart => ($this->columnStart + 1),
+                default => ($this->columnStart + 1).'-'.($this->columnEnd + 1),
+            };
         }
 
-        if ('*' === $cellEnd) {
-            return new self($cellStartRow, null, $cellStartCol, -1);
-        }
+        $selection = ($this->rowStart + 1).','.($this->columnStart + 1);
 
-        $cellEndRow = filter_var($found['cer'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
-        $cellEndCol = filter_var($found['cec'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
-        if (false === $cellEndRow || false === $cellEndCol) {
-            throw new FragmentNotFound('The submitted selection `'.$selection.'` is invalid.');
-        }
+        return match (true) {
+            $this->columnEnd === -1 => $selection.'-*',
+            $this->rowStart === $this->rowEnd && $this->columnStart === $this->columnEnd => $selection,
+            default => $selection.'-'.(($this->rowEnd ?? 0) + 1).','.(($this->columnEnd ?? 0) + 1),
+        };
+    }
 
-        --$cellEndRow;
-        --$cellEndCol;
-
-        if ($cellEndRow < $cellStartRow || $cellEndCol < $cellStartCol) {
-            throw new FragmentNotFound('The submitted selection `'.$selection.'` is invalid.');
-        }
-
-        return new self($cellStartRow, $cellEndRow, $cellStartCol, $cellEndCol,);
+    public function columnRange(): ?array
+    {
+        return match (true) {
+            -1 === $this->columnStart => [],
+            null === $this->columnEnd => null,
+            default => range($this->columnStart, $this->columnEnd),
+        };
     }
 }

--- a/src/Fragment/Type.php
+++ b/src/Fragment/Type.php
@@ -15,8 +15,7 @@ namespace League\Csv\Fragment;
 
 enum Type: string
 {
-    case Row = 'row';
-    case Column = 'col';
     case Cell = 'cell';
-    case Unknown = 'unknown';
+    case Column = 'col';
+    case Row = 'row';
 }

--- a/src/FragmentFinder.php
+++ b/src/FragmentFinder.php
@@ -15,12 +15,6 @@ namespace League\Csv;
 
 use ReflectionException;
 use League\Csv\Fragment\Expression;
-use League\Csv\Fragment\Selection;
-use League\Csv\Fragment\Type;
-
-use function array_filter;
-use function array_map;
-use function array_reduce;
 
 class FragmentFinder
 {
@@ -34,53 +28,31 @@ class FragmentFinder
      * @throws InvalidArgument
      * @throws ReflectionException
      * @throws SyntaxError
-     *
-     * @return iterable<int, TabularDataReader>
      */
-    public function findAll(string $expression, TabularDataReader $tabularDataReader): iterable
+    public function findFirst(Expression|string $expression, TabularDataReader $tabularDataReader): ?TabularDataReader
     {
-        return $this->find(Expression::tryFrom($expression), $tabularDataReader);
-    }
-
-    /**
-     * @throws Exception
-     * @throws InvalidArgument
-     * @throws ReflectionException
-     * @throws SyntaxError
-     */
-    public function findFirst(string $expression, TabularDataReader $tabularDataReader): ?TabularDataReader
-    {
-        $fragment = $this->find(Expression::tryFrom($expression), $tabularDataReader)[0];
-
-        return match ([]) {
-            $fragment->first() => null,
-            default => $fragment,
-        };
-    }
-
-    /**
-     * @throws Exception
-     * @throws FragmentNotFound
-     * @throws InvalidArgument
-     * @throws ReflectionException
-     * @throws SyntaxError
-     */
-    public function findFirstOrFail(string $expression, TabularDataReader $tabularDataReader): TabularDataReader
-    {
-        $parsedExpression = Expression::tryFrom($expression);
-        if ([] !== array_filter(
-            $parsedExpression->selections,
-            fn (Selection $selection): bool => -1 === $selection->rowStart && -1 === $selection->columnStart)
-        ) {
-            throw new FragmentNotFound('The expression `'.$expression.'` contains an invalid or an unsupported selection for the tabular data.');
+        $tabularData = Expression::from($expression)->firstFragment($tabularDataReader);
+        if ($tabularData instanceof TabularDataReader && [] !== $tabularData->first()) {
+            return $tabularData;
         }
 
-        $fragment = $this->find($parsedExpression, $tabularDataReader)[0];
+        return null;
+    }
 
-        return match ([]) {
-            $fragment->first() => throw new FragmentNotFound('No fragment found in the tabular data with the expression `'.$expression.'`.'),
-            default => $fragment,
-        };
+    /**
+     * @throws Exception
+     * @throws InvalidArgument
+     * @throws ReflectionException
+     * @throws SyntaxError
+     */
+    public function findFirstOrFail(Expression|string $expression, TabularDataReader $tabularDataReader): TabularDataReader
+    {
+        $parseExpression = !$expression instanceof Expression ? Expression::from($expression) : $expression;
+        if ((string) $parseExpression !== strtolower((string) $expression)) {
+            throw new FragmentNotFound('The expression "' . $expression . '" contains invalid section(s).');
+        }
+
+        return $this->findFirst($parseExpression, $tabularDataReader) ?? throw new FragmentNotFound('No fragment found in the tabular data with the expression `'.$expression.'`.');
     }
 
     /**
@@ -89,120 +61,22 @@ class FragmentFinder
      * @throws ReflectionException
      * @throws SyntaxError
      *
-     * @return array<int, TabularDataReader>
-     */
-    private function find(Expression $expression, TabularDataReader $tabularDataReader): array
-    {
-        return match ($expression->type) {
-            Type::Row => $this->findByRow($expression, $tabularDataReader),
-            Type::Column => $this->findByColumn($expression, $tabularDataReader),
-            Type::Cell => $this->findByCell($expression, $tabularDataReader),
-            Type::Unknown => [ResultSet::createFromRecords()],
-        };
-    }
-
-    /**
-     * @throws Exception
-     * @throws InvalidArgument
-     * @throws SyntaxError
-     * @throws ReflectionException
+     * @return iterable<TabularDataReader>
+     * @see Expression::fragment()
      *
-     * @return array<TabularDataReader>
+     * @codeCoverageIgnore
+     * @deprecated since version 9.17.0
      */
-    private function findByRow(Expression $expression, TabularDataReader $tabularDataReader): array
+    public function findAll(Expression|string $expression, TabularDataReader $tabularDataReader): iterable
     {
-        $selections = array_filter($expression->selections, fn (Selection $selection): bool => -1 < $selection->rowStart);
-        if ([] === $selections) {
-            return [ResultSet::createFromRecords()];
+        $found = false;
+        foreach (Expression::from($expression)->fragment($tabularDataReader) as $tabularData) {
+            $found = true;
+            yield $tabularData;
         }
 
-        $rowFilter = fn(array $record, int $offset): bool => [] !== array_filter(
-                $selections,
-                fn(Selection $selection) => $offset >= $selection->rowStart &&
-                    (null === $selection->rowEnd || $offset <= $selection->rowEnd)
-            );
-
-        return [Statement::create()->where($rowFilter)->process($tabularDataReader)];
-    }
-
-    /**
-     * @throws Exception
-     * @throws InvalidArgument
-     * @throws ReflectionException
-     * @throws SyntaxError
-     *
-     * @return array<TabularDataReader>
-     */
-    private function findByColumn(Expression $expression, TabularDataReader $tabularDataReader): array
-    {
-        $header = $tabularDataReader->getHeader();
-        if ([] === $header) {
-            $header = $tabularDataReader->first();
+        if (false === $found) {
+            yield ResultSet::createFromRecords();
         }
-
-        $nbColumns = count($header);
-        $selections = array_filter($expression->selections, fn(Selection $selection) => -1 < $selection->columnStart);
-        if ([] === $selections) {
-            return [ResultSet::createFromRecords()];
-        }
-
-        /** @var array<int> $columns */
-        $columns = array_reduce(
-            $selections,
-            fn (array $columns, Selection $selection): array => [
-                ...$columns,
-                ...match (($columnRange = $selection->columnRange())) {
-                    null => range($selection->columnStart, $nbColumns - 1),
-                    default => $selection->columnEnd > $nbColumns || $selection->columnEnd === -1 ? range($selection->columnStart, $nbColumns - 1) : $columnRange,
-                }
-            ],
-            []
-        );
-
-        return [match ([]) {
-            $columns => ResultSet::createFromRecords(),
-            default => Statement::create()->select(...$columns)->process($tabularDataReader),
-        }];
-    }
-
-    /**
-     * @throws Exception
-     * @throws InvalidArgument
-     * @throws ReflectionException
-     * @throws SyntaxError
-     *
-     * @return array<TabularDataReader>
-     */
-    private function findByCell(Expression $expression, TabularDataReader $tabularDataReader): array
-    {
-        $header = $tabularDataReader->getHeader();
-        if ([] === $header) {
-            $header = $tabularDataReader->first();
-        }
-
-        $nbColumns = count($header);
-        $selections = array_filter(
-            $expression->selections,
-            fn(Selection $selection) => -1 < $selection->rowStart && -1 < $selection->columnStart
-        );
-        if ([] === $selections) {
-            return [ResultSet::createFromRecords()];
-        }
-
-        return array_map(
-            fn (Selection $selection): TabularDataReader => Statement::create()
-                ->where(
-                    fn (array $record, int $offset): bool => $offset >= $selection->rowStart &&
-                        (null === $selection->rowEnd || $offset <= $selection->rowEnd)
-                )
-                ->select(
-                    ...match (($columnRange = $selection->columnRange())) {
-                        null => range($selection->columnStart, $nbColumns - 1),
-                        default => $selection->columnEnd > $nbColumns || $selection->columnEnd === -1 ? range($selection->columnStart, $nbColumns - 1) : $columnRange,
-                    }
-                )
-                ->process($tabularDataReader),
-            $selections
-        );
     }
 }

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -17,6 +17,7 @@ use CallbackFilterIterator;
 use Closure;
 use Iterator;
 use JsonSerializable;
+use League\Csv\Fragment\Expression;
 use League\Csv\Serializer\Denormalizer;
 use League\Csv\Serializer\MappingFailed;
 use League\Csv\Serializer\TypeCastingFailed;
@@ -413,12 +414,12 @@ class Reader extends AbstractCsv implements TabularDataReader, JsonSerializable
         return Statement::create()->orderBy($orderBy)->process($this);
     }
 
-    public function matching(string $expression): iterable
+    public function matching(Expression|string $expression): iterable
     {
-        return FragmentFinder::create()->findAll($expression, $this);
+        return Expression::from($expression)->fragment($this);
     }
 
-    public function matchingFirst(string $expression): ?TabularDataReader
+    public function matchingFirst(Expression|string $expression): ?TabularDataReader
     {
         return FragmentFinder::create()->findFirst($expression, $this);
     }
@@ -427,7 +428,7 @@ class Reader extends AbstractCsv implements TabularDataReader, JsonSerializable
      * @throws SyntaxError
      * @throws FragmentNotFound
      */
-    public function matchingFirstOrFail(string $expression): TabularDataReader
+    public function matchingFirstOrFail(Expression|string $expression): TabularDataReader
     {
         return FragmentFinder::create()->findFirstOrFail($expression, $this);
     }

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -20,6 +20,7 @@ use Generator;
 use Iterator;
 use IteratorIterator;
 use JsonSerializable;
+use League\Csv\Fragment\Expression;
 use League\Csv\Serializer\Denormalizer;
 use League\Csv\Serializer\MappingFailed;
 use League\Csv\Serializer\TypeCastingFailed;
@@ -269,12 +270,12 @@ class ResultSet implements TabularDataReader, JsonSerializable
         return new self(new MapIterator($this, $callback), $hasHeader ? $header : []);
     }
 
-    public function matching(string $expression): iterable
+    public function matching(Expression|string $expression): iterable
     {
-        return FragmentFinder::create()->findAll($expression, $this);
+        return Expression::from($expression)->fragment($this);
     }
 
-    public function matchingFirst(string $expression): ?TabularDataReader
+    public function matchingFirst(Expression|string $expression): ?TabularDataReader
     {
         return FragmentFinder::create()->findFirst($expression, $this);
     }
@@ -283,7 +284,7 @@ class ResultSet implements TabularDataReader, JsonSerializable
      * @throws SyntaxError
      * @throws FragmentNotFound
      */
-    public function matchingFirstOrFail(string $expression): TabularDataReader
+    public function matchingFirstOrFail(Expression|string $expression): TabularDataReader
     {
         return FragmentFinder::create()->findFirstOrFail($expression, $this);
     }

--- a/src/TabularDataReaderTestCase.php
+++ b/src/TabularDataReaderTestCase.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 #[Group('tabulardata')]
 abstract class TabularDataReaderTestCase extends TestCase
@@ -232,13 +233,31 @@ abstract class TabularDataReaderTestCase extends TestCase
 
     #[Test]
     #[DataProvider('provideInvalidExpressions')]
+    public function it_will_fail_to_parse_invalid_expression(string $expression): void
+    {
+        $this->expectException(Throwable::class);
+
+        iterator_to_array($this->tabularData()->matching($expression));
+    }
+
+    public static function provideInvalidExpressions(): iterable
+    {
+        return [
+            'expression selection is invalid for cell 1' => ['expression' => 'cell=5'],
+            'expression selection is invalid for row or column 1' => ['expression' => 'row=4,3'],
+            'expression selection is invalid for row or column 2' => ['expression' => 'row=four-five'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('provideExpressionWithIgnoredSelections')]
     public function it_will_return_null_on_invalid_expression(string $expression): void
     {
         self::assertNull($this->tabularData()->matchingFirst($expression));
     }
 
     #[Test]
-    #[DataProvider('provideInvalidExpressions')]
+    #[DataProvider('provideExpressionWithIgnoredSelections')]
     public function it_will_fail_to_parse_the_expression(string $expression): void
     {
         $this->expectException(FragmentNotFound::class);
@@ -246,22 +265,18 @@ abstract class TabularDataReaderTestCase extends TestCase
         $this->tabularData()->matchingFirstOrFail($expression);
     }
 
-    public static function provideInvalidExpressions(): iterable
+    public static function provideExpressionWithIgnoredSelections(): iterable
     {
         return [
-            'missing expression type' => ['2-4'],
             'missing expression selection row' => ['row='],
             'missing expression selection cell' => ['cell='],
             'missing expression selection coll' => ['col='],
-            'expression selection is invalid for cell 1' => ['cell=5'],
             'expression selection is invalid for cell 2' => ['cell=0,3'],
             'expression selection is invalid for cell 3' => ['cell=3,0'],
             'expression selection is invalid for cell 4' => ['cell=1,3-0,4'],
             'expression selection is invalid for cell 5' => ['cell=1,3-4,0'],
             'expression selection is invalid for cell 6' => ['cell=0,3-1,4'],
             'expression selection is invalid for cell 7' => ['cell=1,0-2,3'],
-            'expression selection is invalid for row or column 1' => ['row=4,3'],
-            'expression selection is invalid for row or column 2' => ['row=four-five'],
             'expression selection is invalid for row or column 3' => ['row=0-3'],
             'expression selection is invalid for row or column 4' => ['row=3-0'],
         ];
@@ -270,13 +285,13 @@ abstract class TabularDataReaderTestCase extends TestCase
     #[Test]
     public function it_returns_multiple_selections_in_one_tabular_data_instance(): void
     {
-        self::assertCount(1, $this->tabularData()->matching('row=1-2;5-4;2-4'));
+        self::assertSame(1, iterator_count($this->tabularData()->matching('row=1-2;5-4;2-4')));
     }
 
     #[Test]
     public function it_returns_no_selection(): void
     {
-        self::assertCount(1, $this->tabularData()->matching('row=5-4'));
+        self::assertSame(0, iterator_count($this->tabularData()->matching('row=5-4')));
     }
 
     #[Test]


### PR DESCRIPTION
 Using a non empty string for `$escape` to is deprecated in PHP 8.4, see https://github.com/php/php-src/pull/15365

As far as I understand, using `\\` for `$enclosure` and `` for `$escape` will result in the same, according to https://www.php.net/manual/fr/function.fgetcsv.php

