### PR TITLE
Adding JsonConverter::chunkSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All Notable changes to `Csv` will be documented in this file
 
+## [Next](https://github.com/thephpleague/csv/compare/9.17.0...master) - TBD
+
+### Added
+
+- `League\Csv\JsonConverter::chunkSize`
+
+### Deprecated
+
+- None
+
+### Fixed
+
+- None
+
+### Remove
+
+- None
+
 ## [9.17.0](https://github.com/thephpleague/csv/compare/9.16.0...9.17.0) - 2024-10-10
 
 ### Added

--- a/docs/9.0/converter/json.md
+++ b/docs/9.0/converter/json.md
@@ -110,6 +110,25 @@ structure. The resulting conversion may differ to what you expect. This callback
 specify how each item will be converted. The formatter should return a type that can be handled
 by PHP `json_encode` function.
 
+### Chunk Size
+
+<p class="message-notice">available since version <code>9.18.0</code></p>
+
+```php
+public JsonConverter::chunkSize(int $chunkSize): self
+```
+
+This method sets the number of rows to buffer before convert into JSON string. This allow
+for faster conversion while retaining the low memory usage. Of course, the default
+chunk size can vary for one scenario to another. The correct size is therefore
+left to the user discretion. By default, the value is `500`. The value can not
+be lower than one otherwise a exception will be thrown.
+
+```php
+$converter = JsonConverter::create()->chunkSize(1_000);
+$converter->chunkSize; //returns the value used
+```
+
 ## Conversion
 
 ```php

--- a/src/JsonConverterTest.php
+++ b/src/JsonConverterTest.php
@@ -66,6 +66,7 @@ final class JsonConverterTest extends TestCase
                 ->addFlags(0)
                 ->removeFlags(0)
                 ->depth(512)
+                ->chunkSize(500)
         );
     }
 
@@ -83,6 +84,14 @@ final class JsonConverterTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         JsonConverter::create()->indentSize(0); /* @phpstan-ignore-line */
+    }
+
+    #[Test]
+    public function it_fails_if_the_chunk_size_is_invalud(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        JsonConverter::create()->chunkSize(0); /* @phpstan-ignore-line */
     }
 
     #[Test]


### PR DESCRIPTION
```php
public JsonConverter::chunkSize(int $chunkSize): self
```

This method sets the number of rows to buffer before calling the `json_encode` function. This allow for faster conversion while retaining the low memory usage. Of course, the optimal chunk size will vary depending on the use case. 

By default, the value is `500`. 

The value can not be lower than `1` otherwise a exception will be thrown.