### PR TITLE
Remove stream filters in Stream destructor only if they are still valid resources

### DIFF
--- a/src/ReaderTest.php
+++ b/src/ReaderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\Csv;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Group;
 use SplFileObject;
 use SplTempFileObject;
@@ -636,5 +637,19 @@ CSV;
 
         Reader::createFromString($csv)
             ->getRecords(['Annee' => 'Year', 'Prenom' => 'Firstname', 'Nombre' => 'Count']);
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testStreamWithFiltersDestructsGracefully(): void
+    {
+        /** @var resource $fp */
+        $fp = fopen('php://temp', 'r+');
+        fputcsv($fp, ['abc', '123'], escape: '');
+
+        $csv = Reader::createFromStream($fp);
+        $csv->addStreamFilter('convert.iconv.UTF-8/UTF-16');
+
+        // An explicitly closed file handle makes the stream filter resources invalid
+        fclose($fp);
     }
 }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -81,7 +81,11 @@ final class Stream implements SeekableIterator
 
     public function __destruct()
     {
-        array_walk_recursive($this->filters, fn ($filter): bool => @stream_filter_remove($filter));
+        array_walk_recursive($this->filters, static function ($filter): void {
+            if (is_resource($filter)) {
+                @stream_filter_remove($filter);
+            }
+        });
 
         if ($this->should_close_stream) {
             set_error_handler(fn (int $errno, string $errstr, string $errfile, int $errline) => true);


### PR DESCRIPTION
When a `Reader` or `Writer` has a stream filter and the handle to the stream is closed manually in code, there's a fatal error in the `Stream` destructor.

To reproduce: in current `master` branch, the test case in the PR fails with a fatal error in the `Stream` destructor:

```
PHP Fatal error:  Uncaught TypeError: stream_filter_remove(): supplied resource is not a valid stream filter resource in /path/to/example/vendor/league/csv/src/Stream.php:84
Stack trace:
#0 /path/to/example/vendor/league/csv/src/Stream.php(84): stream_filter_remove()
#1 [internal function]: League\Csv\Stream->League\Csv\{closure}()
#2 /path/to/example/vendor/league/csv/src/Stream.php(84): array_walk_recursive()
#3 [internal function]: League\Csv\Stream->__destruct()
#4 {main}
  thrown in /path/to/example/vendor/league/csv/src/Stream.php on line 84
```