### PR TITLE
Fix Comparison::CONTAINS to check is_string before str_compare

### DIFF
--- a/src/Query/Constraint/Comparison.php
+++ b/src/Query/Constraint/Comparison.php
@@ -99,7 +99,7 @@ enum Comparison: string
             self::NotIn => !in_array($subject, $reference, self::isSingleValue($subject)), /* @phpstan-ignore-line */
             self::Regexp => is_string($subject) && 1 === preg_match($reference, $subject), /* @phpstan-ignore-line */
             self::NotRegexp => is_string($subject) && 1 !== preg_match($reference, $subject), /* @phpstan-ignore-line */
-            self::Contains => str_contains($subject, $reference), /* @phpstan-ignore-line */
+            self::Contains => is_string($subject) && str_contains($subject, $reference), /* @phpstan-ignore-line */
             self::NotContain => is_string($subject) && !str_contains($subject, $reference), /* @phpstan-ignore-line */
             self::StartsWith => is_string($subject) && str_starts_with($subject, $reference), /* @phpstan-ignore-line */
             self::EndsWith => is_string($subject) && str_ends_with($subject, $reference), /* @phpstan-ignore-line */

--- a/src/StatementTest.php
+++ b/src/StatementTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace League\Csv;
 
+use League\Csv\Query\Constraint\Comparison;
 use League\Csv\Query\QueryException;
 use OutOfBoundsException;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -239,5 +240,23 @@ CSV;
             ->offset(2);
 
         self::assertSame([], $constraints->process($csv)->nth(42));
+    }
+
+    public function testItCanCompareNullValue(): void
+    {
+        $document = <<<CSV
+Title,Name,Number
+Commander,Fred,104
+Officer,John,117
+Major,Avery
+CSV;
+
+        $csv = Reader::createFromString($document)->setHeaderOffset(0);
+        $statement = Statement::create()->andWhere('Number', Comparison::Contains, '117');
+
+        // The count is really just to have the comparison iterate the entire
+        // list. The last item in the list will break the comparison because of
+        // the lack of is_string(...).
+        self::assertSame(1, $statement->process($csv)->count());
     }
 }


### PR DESCRIPTION
In Comparison there is a line that says 

```php
self::Contains => str_contains($subject, $reference), /* @phpstan-ignore-line */
```

Since this is checking `$subject` with `str_contains` it should check first if it is a string. This seems to have been handled in other various comparisons already (e.g. `self::Regexp => is_string($subject) && 1 === preg_match($reference, $subject), /* @phpstan-ignore-line */`)

```
TypeError: str_contains(): Argument #1 ($haystack) must be of type string, null given
/var/www/src/Query/Constraint/Comparison.php:102
/var/www/src/Query/Constraint/Column.php:78
/var/www/src/Query/Constraint/Criteria.php:47
/var/www/src/Query/Constraint/Criteria.php:108
/var/www/src/ResultSet.php:395
/var/www/src/StatementTest.php:260
```