### PR TITLE
match denormalized properties, fixes #565

### DIFF
--- a/src/Serializer/Denormalizer.php
+++ b/src/Serializer/Denormalizer.php
@@ -386,8 +386,11 @@ final class Denormalizer
         return false; // No match
     }
 
-    private static function normalizeKey(string $key): string
+    private static function normalizeKey(?string $key): ?string
     {
+        if (is_null($key)) {
+            return null;
+        }
         // Remove spaces and underscores
         $key = str_replace([' ', '_'], '', $key);
 

--- a/src/Serializer/Denormalizer.php
+++ b/src/Serializer/Denormalizer.php
@@ -341,7 +341,8 @@ final class Denormalizer
             }
 
             /** @var int<0, max>|false $index */
-            $index = array_search($offset, $propertyNames, true);
+            $index = self::normalizedMatch($offset, $propertyNames);
+
             if (false === $index) {
                 throw new MappingFailed('The `'.$offset.'` property could not be found in the property names list; Please verify your property names list.');
             }
@@ -370,7 +371,34 @@ final class Denormalizer
         };
     }
 
-    /**
+
+
+    public static function normalizedMatch(string $needle, array $haystack): int|false
+    {
+        $normalizedNeedle = self::normalizeKey($needle);
+
+        foreach ($haystack as $index => $item) {
+            if (self::normalizeKey($item) === $normalizedNeedle) {
+                return $index; // Return the matching index
+            }
+        }
+
+        return false; // No match
+    }
+
+    private static function normalizeKey(string $key): string
+    {
+        // Remove spaces and underscores
+        $key = str_replace([' ', '_'], '', $key);
+
+        // Convert camelCase to lowercase (flatten everything)
+        $key = strtolower(preg_replace('/([a-z])([A-Z])/', '$1$2', $key));
+
+        return $key;
+    }
+
+
+/**
      * @throws MappingFailed
      */
     private function getMethodFirstArgument(ReflectionMethod $reflectionMethod): ReflectionParameter

--- a/src/Serializer/DenormalizerTest.php
+++ b/src/Serializer/DenormalizerTest.php
@@ -63,6 +63,50 @@ final class DenormalizerTest extends TestCase
         }
     }
 
+    public function testItFindsNormalizedColumns(): void
+    {
+        $records = [
+            [
+                'observedOn' => '2023-10-30',
+                'temperature' => '-1.5',
+                'place' => 'Abidjan',
+            ],
+            [
+                'observed_on' => '2023-10-30',
+                'temperature' => '-3',
+                'place' => 'Abidjan',
+            ],
+            [
+                'observed On' => '2023-10-30',
+                'temperature' => '-3',
+                'place' => 'Abidjan',
+            ],
+            [
+                'observedon' => '2023-10-30',
+                'temperature' => '-3',
+                'place' => 'Abidjan',
+            ],
+        ];
+
+        $class = new class (5, Place::Yamoussokro, new DateTimeImmutable()) {
+            public function __construct(
+                public readonly float $temperature,
+                public readonly Place $place,
+                #[MapCell(
+                    options: ['format' => '!Y-m-d', 'timezone' => 'Africa/Kinshasa'],
+                )]
+                public readonly DateTimeInterface $observedOn
+            ) {
+            }
+        };
+
+        $results = [...Denormalizer::assignAll($class::class, $records, ['observedOn', 'temperature', 'place'])];
+        self::assertCount(4, $results);
+        foreach ($results as $result) {
+            self::assertInstanceOf($class::class, $result);
+        }
+    }
+
     public function testItConvertsARecordsToAnObjectUsingRecordAttribute(): void
     {
         $record = [


### PR DESCRIPTION
instead of an exact property match, use denormalized columns:

```

        $records = [
            [
                'observedOn' => '2023-10-30',
                'temperature' => '-1.5',
                'place' => 'Abidjan',
            ],
            [
                'observed_on' => '2023-10-30',
                'temperature' => '-3',
                'place' => 'Abidjan',
            ],
            [
                'observed On' => '2023-10-30',
                'temperature' => '-3',
                'place' => 'Abidjan',
            ],
            [
                'observedon' => '2023-10-30',
                'temperature' => '-3',
                'place' => 'Abidjan',
            ],
        ];

```