### PR TITLE
No need to do second `instanceof` in `insertAll()` when first satisfied

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -119,9 +119,7 @@ class Writer extends AbstractCsv implements TabularDataWriter
     {
         if ($records instanceof TabularDataProvider) {
             $records = $records->getTabularData();
-        }
-
-        if ($records instanceof TabularData) {
+        } elseif ($records instanceof TabularData) {
             $records = $records->getRecords();
         }
 


### PR DESCRIPTION
I guess inconsequentially more performant, I've not checked. Just easier for brains to read.