### PR TITLE
fix: Initialize `$callback` property to null to prevent uninitialized property

### DIFF
--- a/src/CallbackStreamFilter.php
+++ b/src/CallbackStreamFilter.php
@@ -41,7 +41,7 @@ final class CallbackStreamFilter extends php_user_filter
     private static array $filters = [];
 
     /** @var ?Closure(string, mixed): string */
-    private ?Closure $callback;
+    private ?Closure $callback = null;
 
     public function onCreate(): bool
     {


### PR DESCRIPTION
 ### Description                                                                                                                                                    
  - Initialize the `$callback` property in `CallbackStreamFilter` to `null` to prevent potential uninitialized property access errors if the property is accessed before `onCreate()` is called. 
  
### Why:
In PHP 7.4+ ([document](https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.typed-properties)), accessing a typed property before it is initialized throws an Error. While `onCreate()` is intended to set this property, certain edge cases or manual instantiation of the filter class (e.g., in unit tests) could trigger this fatal error. Initializing it to null ensures the class remains in a predictable state.