### PR TITLE
fix: Use `STREAM_FILTER_WRITE` in `prependStreamFilterOnWrite` method

### DIFF
--- a/src/AbstractCsv.php
+++ b/src/AbstractCsv.php
@@ -468,7 +468,7 @@ abstract class AbstractCsv implements ByteSequence
     {
         $this->document instanceof Stream || throw UnavailableFeature::dueToUnsupportedStreamFilterApi(get_class($this->document));
 
-        $this->document->prependFilter($filtername, STREAM_FILTER_READ, $params);
+        $this->document->prependFilter($filtername, STREAM_FILTER_WRITE, $params);
         $this->stream_filters[$filtername] = true;
         $this->resetProperties();
         $this->input_bom = null;


### PR DESCRIPTION
 ## What I have done
`prependStreamFilterOnWrite()` was incorrectly using `STREAM_FILTER_READ` instead of `STREAM_FILTER_WRITE` when calling `$this->document->prependFilter()`. 

This caused the filter to be applied to the read stream instead of the write stream. 