### PR TITLE
fix: Ensure unmatched optional capture group is treated as null in `parseRowColumnSelection`

### DIFF
--- a/src/FragmentFinder.php
+++ b/src/FragmentFinder.php
@@ -292,18 +292,17 @@ class FragmentFinder
      */
     private function parseRowColumnSelection(string $selection): array
     {
-        if (1 !== preg_match(self::REGEXP_ROWS_COLUMNS_SELECTION, $selection, $found)) {
+        if (1 !== preg_match(self::REGEXP_ROWS_COLUMNS_SELECTION, $selection, $found, PREG_UNMATCHED_AS_NULL)) {
             return [-1, 0];
         }
 
-        $start = $found['start'];
-        $end = $found['end'] ?? null;
-        $start = filter_var($start, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        $start = filter_var($found['start'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
         if (false === $start) {
             return [-1, 0];
         }
         --$start;
 
+        $end = $found['end'];
         if (null === $end || '*' === $end) {
             return [$start, $end];
         }

--- a/src/TabularDataReaderTestCase.php
+++ b/src/TabularDataReaderTestCase.php
@@ -273,6 +273,37 @@ abstract class TabularDataReaderTestCase extends TestCase
             'expression' => 'cell=48,12',
             'expected' => null,
         ];
+
+        yield 'multiple single rows without range endpoint' => [
+            'expression' => 'row=1;3',
+            'expected' => [
+                0 => ['date', 'temperature', 'place'],
+                1 => ['2011-01-02', '-1', 'Galway'],
+            ],
+        ];
+
+        yield 'mixed single row and row range' => [
+            'expression' => 'row=1;3-5',
+            'expected' => [
+                0 => ['date', 'temperature', 'place'],
+                1 => ['2011-01-02', '-1', 'Galway'],
+                2 => ['2011-01-03', '0', 'Galway'],
+                3 => ['2011-01-01', '6', 'Berkeley'],
+            ],
+        ];
+
+        yield 'multiple single columns without range endpoint' => [
+            'expression' => 'col=1;3',
+            'expected' => [
+                0 => [0 => 'date', 2 => 'place'],
+                1 => [0 => '2011-01-01', 2 => 'Galway'],
+                2 => [0 => '2011-01-02', 2 => 'Galway'],
+                3 => [0 => '2011-01-03', 2 => 'Galway'],
+                4 => [0 => '2011-01-01', 2 => 'Berkeley'],
+                5 => [0 => '2011-01-02', 2 => 'Berkeley'],
+                6 => [0 => '2011-01-03', 2 => 'Berkeley'],
+            ],
+        ];
     }
 
     #[Test]
@@ -323,6 +354,7 @@ abstract class TabularDataReaderTestCase extends TestCase
             'expression selection is invalid for cell 7' => ['cell=1,0-2,3'],
             'expression selection is invalid for row or column 3' => ['row=0-3'],
             'expression selection is invalid for row or column 4' => ['row=3-0'],
+            'all single row selections are out of bounds' => ['row=0;0'],
         ];
     }
 
@@ -350,6 +382,23 @@ abstract class TabularDataReaderTestCase extends TestCase
         $this->expectException(FragmentNotFound::class);
 
         $this->tabularDataWithoutHeader()->matchingFirstOrFail('row=42');
+    }
+
+    #[Test]
+    public function it_throws_when_expression_contains_invalid_single_selection_alongside_valid(): void
+    {
+        $this->expectException(FragmentNotFound::class);
+
+        $this->tabularDataWithoutHeader()->matchingFirstOrFail('row=0;3');
+    }
+
+    #[Test]
+    public function it_returns_valid_rows_when_mixed_selection_contains_invalid_single_row(): void
+    {
+        $result = $this->tabularDataWithoutHeader()->matchingFirst('row=0;3');
+
+        self::assertNotNull($result);
+        self::assertSame([0 => ['2011-01-02', '-1', 'Galway']], [...$result]);
     }
 
     /***************************


### PR DESCRIPTION
## Summary

### What I have done
- Added `PREG_UNMATCHED_AS_NULL` flag to the `preg_match` call in `parseRowColumnSelection()`
- Without this flag, PHP sets unmatched named capturing groups to `''` (empty string) rather than leaving them absent, causing `$found['end'] ?? null` to return `''`instead of `null`
- This bug caused single-number selections (e.g. `row=1`, `col=2`) to always fail validation when combined with semicolon-separated expressions (e.g. `row=1;3`, `col=1;3`)

### Where I have changed
- `src/FragmentFinder.php`: Add `PREG_UNMATCHED_AS_NULL` to `preg_match` and simplify `$end` assignment from `$found['end'] ?? null` to `$found['end']`
- `src/TabularDataReaderTestCase.php`: Add test cases covering following cases
    - Multiple single-number row/column selections (`row=1;3`, `col=1;3`)
    - Mixed single and range selections (`row=1;3-5`)
    - All-invalid single selections (`row=0;0`)
    - Mixed valid/invalid selections — `matchingFirst` returns partial results, `matchingFirstOrFail` throws `FragmentNotFound`
    
### Test Plan

  | Expression | What is verified |
  |---|---|
  | `row=1;3` | Two single-number row selections both resolve correctly without a range endpoint |
  | `row=1;3-5` | A single-number selection and a range selection can coexist in one expression |
  | `col=1;3` | Two single-number column selections both resolve correctly without a range endpoint |
  | `row=0;0` | All-invalid single selections yield `null` from `matchingFirst` and throw from `matchingFirstOrFail` |
  | `row=0;3` (×2) | When valid and invalid selections are mixed, `matchingFirst` returns only the valid result while `matchingFirstOrFail` throws `FragmentNotFound` |
    

    
### Test Cases Result
<img width="658" height="448" alt="screen shot 2026-05-29 8 57 44" src="https://github.com/user-attachments/assets/fbd20436-d988-422a-97c6-f3d6ca934943" />
