### PR TITLE
Fix forceEnclosure quote doubling with an empty escape character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All Notable changes to `Csv` will be documented in this file
 
 ### Fixed
 
-- None
+- `Writer::forceEnclosure` now doubles embedded enclosures when the escape character is the empty string.
 
 ### Remove
 

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -59,10 +59,14 @@ class Writer extends AbstractCsv implements TabularDataWriter
     {
         parent::resetProperties();
 
-        $this->enclosure_replace = [
-            [$this->enclosure, $this->escape.$this->enclosure.$this->enclosure],
-            [$this->enclosure.$this->enclosure, $this->escape.$this->enclosure],
-        ];
+        // With an empty escape the two-step replacement cancels itself, so
+        // fall back to plain RFC-4180 enclosure doubling as fputcsv does.
+        $this->enclosure_replace = '' === $this->escape
+            ? [[$this->enclosure], [$this->enclosure.$this->enclosure]]
+            : [
+                [$this->enclosure, $this->escape.$this->enclosure.$this->enclosure],
+                [$this->enclosure.$this->enclosure, $this->escape.$this->enclosure],
+            ];
     }
 
     protected function insertRecord(array $record): int|false

--- a/src/WriterTest.php
+++ b/src/WriterTest.php
@@ -195,6 +195,72 @@ final class WriterTest extends TestCase
         self::assertFalse($writer->encloseAll());
     }
 
+    /**
+     * @param array<string> $record
+     *
+     * @see https://github.com/thephpleague/csv/issues/532
+     */
+    #[DataProvider('forceEnclosureEmptyEscapeProvider')]
+    public function testForceEnclosureWithEmptyEscapeDoublesQuotes(string $expected, array $record): void
+    {
+        $writer = Writer::fromString();
+        $writer->setEscape('');
+        $writer->forceEnclosure();
+        $writer->insertOne($record);
+
+        $csv = $writer->toString();
+        self::assertSame($expected."\n", $csv);
+
+        // the writer must be able to parse back its own output unchanged
+        $reader = Reader::fromString($csv);
+        $reader->setEscape('');
+        self::assertSame([$record], [...$reader->getRecords()]);
+    }
+
+    public static function forceEnclosureEmptyEscapeProvider(): array
+    {
+        return [
+            'embedded enclosure' => [
+                'expected' => '"va""lue","b"',
+                'record' => ['va"lue', 'b'],
+            ],
+            'consecutive enclosures' => [
+                'expected' => '"a""""b","c"',
+                'record' => ['a""b', 'c'],
+            ],
+            'enclosure and delimiter' => [
+                'expected' => '"x""y,z","d"',
+                'record' => ['x"y,z', 'd'],
+            ],
+            'delimiter only' => [
+                'expected' => '"p,q","e"',
+                'record' => ['p,q', 'e'],
+            ],
+            'embedded newline' => [
+                'expected' => "\"li\nne\",\"f\"",
+                'record' => ["li\nne", 'f'],
+            ],
+            'no special char' => [
+                'expected' => '"plain","x"',
+                'record' => ['plain', 'x'],
+            ],
+            'wrapped in enclosures' => [
+                'expected' => '"""wrap""","l"',
+                'record' => ['"wrap"', 'l'],
+            ],
+        ];
+    }
+
+    public function testForceEnclosureWithLegacyEscapeIsUnchanged(): void
+    {
+        $writer = Writer::fromString();
+        $writer->forceEnclosure();
+        $writer->insertOne(['to"to', 'foo\"bar']);
+
+        // the legacy non-empty escape path must keep doubling once, never twice
+        self::assertSame('"to""to","foo\"bar"'."\n", $writer->toString());
+    }
+
     public function testAddValidationRules(): void
     {
         $this->expectException(CannotInsertRecord::class);


### PR DESCRIPTION
## Bug Fix

| Information | Description |
|--------------|---------|
| Version | 9.x (master) |
| PHP version | 8.4+ |
| OS Platform | any |

### Summary

`Writer::forceEnclosure()` combined with an empty escape character (`setEscape('')`) emits CSV where embedded enclosures are **not** doubled, so the writer produces output its own `Reader` parses incorrectly.

The empty escape is the configuration to reach for on PHP 8.4+, since it is the only value that does not trigger the `fputcsv`/`str_getcsv` escape deprecation (see #532).

Root cause is the hand-rolled escaper in `resetProperties()`:

```php
$this->enclosure_replace = [
    [$this->enclosure, $this->escape.$this->enclosure.$this->enclosure],
    [$this->enclosure.$this->enclosure, $this->escape.$this->enclosure],
];
```

With a non-empty escape the second search term is `<escape>""`, which never matches the doubled output of the first pass, so a single enclosure is doubled once. With an empty escape both `$this->escape.$this->enclosure` terms degenerate to plain enclosures: the first pass doubles every `"` into `""` and the second pass collapses every `""` back into `"`. Net effect: no escaping at all.

Minimal repro:

```php
$w = Writer::fromString();
$w->setEscape('');
$w->forceEnclosure();
$w->insertOne(['va"lue', 'b']);

$w->toString();     // "va"lue","b"    -- enclosure NOT doubled (invalid per RFC 4180 2.7)
                    // expected:  "va""lue","b"

$r = Reader::fromString($w->toString());
$r->setEscape('');
[...$r->getRecords()][0];   // ['value"', 'b']  -- round-trip corrupted
```

The self-oracle is the library itself: `Reader::getRecords()` over `Writer` output must return the original record. The default `necessaryEnclosure` path (native `fputcsv`) already does the correct RFC 4180 doubling for an empty escape; only the `ENCLOSE_ALL` hand-rolled path diverges.

### Fix

Build the replacement map as plain RFC 4180 enclosure doubling when the escape is empty, matching the `fputcsv`-based path. The non-empty escape branch is untouched, so existing `forceEnclosure()` behaviour (and its tests) is byte-for-byte unchanged.

I audited the surrounding code for the same class of defect: `EncloseField` relies on `fputcsv`'s own enclosure rather than the hand-rolled map, and `EscapeFormula` is unrelated CSV-injection handling, so both are unaffected. The defect is localised to `resetProperties()`.

### Tests

Added a data-provider round-trip test for `forceEnclosure()` + `setEscape('')` over fields containing embedded enclosures, delimiters, newlines and plain values, asserting both the exact bytes and that the output round-trips back through `Reader` unchanged. Also added a regression test pinning the legacy non-empty-escape path (no double-doubling).

## Checks before submitting

* [x] Be sure that there isn't already a pull request about this.
* [x] This pull request is about 1 bug fix and nothing more.
* [x] Be sure to always target the lowest supported PHP version.
* [x] Be sure to include tests.
* [x] Be sure to have run `composer test` before submitting the fix.
* [x] Be sure to update the `CHANGELOG.md`
* [ ] Be sure to update the documentation if needed.
