### PR TITLE
Fix EscapeFormula round-trip for fields starting with the escape character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All Notable changes to `Csv` will be documented in this file
 
 ### Fixed
 
-- None
+- `EscapeFormula` round-trip now preserves fields starting with the escape character
 
 ### Remove
 

--- a/src/EscapeFormula.php
+++ b/src/EscapeFormula.php
@@ -21,6 +21,7 @@ use function array_fill_keys;
 use function array_keys;
 use function array_map;
 use function is_string;
+use function str_starts_with;
 
 /**
  * A Formatter to tackle CSV Formula Injection.
@@ -109,7 +110,7 @@ class EscapeFormula
 
         return match (true) {
             null == $strOrNull,
-            !isset($strOrNull[0], $this->special_chars[$strOrNull[0]]) => $cell,
+            !isset($this->special_chars[$strOrNull[0]]) && !str_starts_with($strOrNull, $this->escape) => $cell,
             default => $this->escape.$strOrNull,
         };
     }
@@ -124,10 +125,11 @@ class EscapeFormula
 
         return match (true) {
             null === $strOrNull,
-            !isset($strOrNull[0], $strOrNull[1]),
-            $strOrNull[0] !== $this->escape,
-            !isset($this->special_chars[$strOrNull[1]]) => $cell,
-            default => substr($strOrNull, 1),
+            !str_starts_with($strOrNull, $this->escape),
+            !isset($strOrNull[strlen($this->escape)]),
+            !isset($this->special_chars[$strOrNull[strlen($this->escape)]])
+                && !str_starts_with($strOrNull, $this->escape.$this->escape) => $cell,
+            default => substr($strOrNull, strlen($this->escape)),
         };
     }
 

--- a/src/EscapeFormulaTest.php
+++ b/src/EscapeFormulaTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace League\Csv;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use SplTempFileObject;
@@ -99,5 +100,78 @@ final class EscapeFormulaTest extends TestCase
         $result = array_map($formatter->unescapeRecord(...), iterator_to_array($reader));
         $formatted_records = [['2', '2017-07-25', 'Important Client', '=2+5', '240', "\ttab", "\rcr", '']];
         self::assertEquals($formatted_records, $result);
+    }
+
+    /**
+     * @return iterable<string, array{EscapeFormula, array<mixed>}>
+     */
+    public static function provideRoundTripRecords(): iterable
+    {
+        $records = [
+            'plain text' => ['normal', 'hello world', '2026-07-31', '240'],
+            'formula triggers' => ['=2+5', '-123', '+123', '@handle', "\ttab", "\rcr"],
+            'single trigger character' => ['=', '-', '+', '@'],
+            'escape-led with formula trigger' => ["'=2+5", "'@handle", "'+1", "'-x"],
+            'escape-led with escape character' => ["''quote", "'''"],
+            'escape-led with plain text' => ["'hello", "'apostrophe"],
+            'single escape character' => ["'"],
+            'escape-led with multi-character escape' => ['xyfield', 'xy=2+5'],
+            'custom special character' => ['|pipe', '|formula'],
+            'empty string' => [''],
+            'mixed value types' => [240, 0, null, 1.5, true, (object) 'yes'],
+        ];
+        $formatters = [
+            'default escape' => new EscapeFormula(),
+            'custom escape' => new EscapeFormula('`'),
+            'custom escape and special characters' => new EscapeFormula('\\', ['|']),
+            'multi-character escape' => new EscapeFormula('xy', ['|']),
+            'empty escape' => new EscapeFormula(''),
+        ];
+
+        foreach ($formatters as $formatterName => $formatter) {
+            foreach ($records as $recordName => $record) {
+                yield $formatterName.' / '.$recordName => [$formatter, $record];
+            }
+        }
+    }
+
+    #[DataProvider('provideRoundTripRecords')]
+    public function testEscapeRecordUnescapeRecordRoundTrip(EscapeFormula $formatter, array $record): void
+    {
+        self::assertSame($record, $formatter->unescapeRecord($formatter->escapeRecord($record)));
+    }
+
+    public function testEscapeRecordProtectsEscapeLeadingFields(): void
+    {
+        $formatter = new EscapeFormula();
+        $record = ["'=2+5", "'hello", "'", "'@handle"];
+        $expected = ["''=2+5", "''hello", "''", "''@handle"];
+        self::assertSame($expected, $formatter->escapeRecord($record));
+        self::assertNotEquals($formatter->escapeRecord(['=2+5']), $formatter->escapeRecord(["'=2+5"]));
+    }
+
+    public function testUnescapeRecordIgnoresLiteralEscapeLeadingFields(): void
+    {
+        $formatter = new EscapeFormula();
+        self::assertSame(["'hello", "'plain"], $formatter->unescapeRecord(["'hello", "'plain"]));
+    }
+
+    public function testUnescapeIsInverseOfEscapeOnWriterReaderRoundTrip(): void
+    {
+        $formatter = new EscapeFormula();
+        $record = ['id', '=2+5', "'=text you typed", "'@notmyhandle", 'normal'];
+        $csv = Writer::fromString();
+        $csv->addFormatter($formatter->escapeRecord(...));
+        $csv->insertOne($record);
+
+        $reader = Reader::fromString($csv->toString());
+        $reader->addFormatter($formatter->unescapeRecord(...));
+        self::assertSame($record, $reader->first());
+    }
+
+    public function testUnescapeRecordWithMultiCharacterEscape(): void
+    {
+        $formatter = new EscapeFormula('xy');
+        self::assertSame(['xy=2+5', 'xy'], $formatter->unescapeRecord(['xyxy=2+5', 'xyxy']));
     }
 }


### PR DESCRIPTION
`EscapeFormula::unescapeRecord()` is documented and tested as the exact inverse of `escapeRecord()`, but the pair is not an inverse for fields that start with the escape character itself.

`escapeField()` only prepends the escape character to fields starting with a formula trigger. A field the user typed as `'=2+5` is left untouched, which makes the escape non-injective: `escapeRecord(["'=2+5"]) === escapeRecord(["=2+5"]) === ["'=2+5"]`. On read-back, `unescapeField()` strips the leading `'` whenever the second character is a trigger, so a legitimate `'=text` or `'@handle` field loses its leading quote. The documented write/read round-trip corrupts data.

The fix makes both halves operate on the escape prefix:

- `escapeField()` also prepends the escape character when the field already starts with it, so escaped fields are distinguishable from literal ones;
- `unescapeField()` strips exactly one escape prefix when the remainder starts with a formula trigger or with the escape character, which is the inverse of the new escaping rule. It now also handles multi-character escape strings, which previously never unescaped at all because the old check only compared the first byte.

The existing contracts are unchanged: `unescapeRecord(["'=2+5"])` still returns `["=2+5"]` and the reader examples in the docs behave the same.

Round-trip tests now cover every first-two-character regime (formula trigger, escape+trigger, escape+escape, escape+plain, plain text) with the default, custom and multi-character escapes.

Repro (current master):

```php
$ef = new EscapeFormula();
$record = ['id', '=2+5', "'=text you typed", "'@notmyhandle", 'normal'];
$writer = Writer::fromString();
$writer->addFormatter($ef->escapeRecord(...));
$writer->insertOne($record);
$reader = Reader::fromString($writer->toString());
$reader->addFormatter($ef->unescapeRecord(...));
var_export($reader->first() === $record); // false: '=text you typed / '@notmyhandle lose their leading '
```

Full suite, phpstan (level max) and php-cs-fixer are green locally.
