### PR TITLE
docs: fix truncate method typo in buffer guide

### DIFF
--- a/docs/9.0/writer/buffer.md
+++ b/docs/9.0/writer/buffer.md
@@ -242,7 +242,7 @@ $document->setHeaderOffset(0); //the Reader header will be imported alongside it
 $buffer = Buffer::from($document);  
 $buffer->isEmpty(); // returns false
 $buffer->hasHeader(); // return true
-$buffer->truncrate();
+$buffer->truncate();
 $buffer->isEmpty(); // returns true
 $buffer->hasHeader(); // return true
 ```


### PR DESCRIPTION
The Buffer documentation calls `$buffer->truncrate();`, but there is no such method. `Buffer` exposes `truncate()` (see `src/Buffer.php`), and the surrounding examples on this same page already use `truncate()` correctly. Fixed the typo so the sample runs.
