### PR TITLE
Reset the fields a DateTimeField format does not parse instead of taking them from the current time

### DIFF
--- a/src/Schema/DateTimeField.php
+++ b/src/Schema/DateTimeField.php
@@ -191,7 +191,8 @@ final class DateTimeField extends FieldEvaluator implements Field
         }
 
         try {
-            $value = $this->outputClass::createFromFormat($this->format, $value, $this->timezone);
+            // `|` resets the fields the format does not parse, which createFromFormat otherwise fills from the current time.
+            $value = $this->outputClass::createFromFormat($this->format.'|', $value, $this->timezone);
             if (false === $value) {
                 return null;
             }

--- a/src/Schema/DateTimeFieldTest.php
+++ b/src/Schema/DateTimeFieldTest.php
@@ -82,6 +82,14 @@ final class DateTimeFieldTest extends TestCase
     {
         self::assertSame('datetime(format=timestamp,timezone=UTC)', DateTimeField::timestamp()->name());
     }
+
+    public function testParseDoesNotTakeUnparsedFieldsFromTheCurrentTime(): void
+    {
+        $result = (new DateTimeField('Y-m-d'))->parse('2024-01-01');
+
+        self::assertInstanceOf(DateTimeImmutable::class, $result);
+        self::assertSame('2024-01-01 00:00:00.000000', $result->format('Y-m-d H:i:s.u'));
+    }
 }
 
 interface MyDateInterface extends DateTimeInterface


### PR DESCRIPTION
`(new DateTimeField('Y-m-d'))->parse('2024-01-01')` returns a date whose time is the wall clock at parse time, so the same input parses to a different value every second.

`DateTimeImmutable::createFromFormat` fills every field the format does not mention from the current time.

Append `|` to the format so unparsed fields reset to zero.

New test fails on master (`Failed asserting that two strings are identical`, time portion is the current time) and passes with the change; `composer phpunit`, `composer phpstan` and `composer phpcs` clean.
