### PR TITLE
Match the TimeField separator literally

### DIFF
--- a/src/Schema/TimeField.php
+++ b/src/Schema/TimeField.php
@@ -21,6 +21,7 @@ use function ctype_digit;
 use function implode;
 use function is_string;
 use function preg_match;
+use function preg_quote;
 use function strlen;
 use function trim;
 
@@ -132,6 +133,6 @@ final class TimeField extends FieldEvaluator implements Field
             }
         );
 
-        return '/^'.implode($this->separator, $patternParts).'$/';
+        return '/^'.implode(preg_quote($this->separator, '/'), $patternParts).'$/';
     }
 }

--- a/src/Schema/TimeFieldTest.php
+++ b/src/Schema/TimeFieldTest.php
@@ -122,4 +122,10 @@ final class TimeFieldTest extends TestCase
             TimeField::hours()->name()
         );
     }
+
+    public function test_separator_is_matched_literally(): void
+    {
+        self::assertNull(TimeField::minutes(separator: '.')->parse('10x30'));
+        self::assertSame('10/30/00', TimeField::minutes(separator: '/')->parse('10/30'));
+    }
 }


### PR DESCRIPTION
`TimeField::minutes(separator: '.')->parse('10x30')` returns `10.30.00` instead of `null`.

The separator is interpolated into the matching regex unquoted, so `.` matches any character.

Wrap it in `preg_quote`.

New test fails on master (`Failed asserting that '10.30.00' is null`) and passes with the change; `composer phpunit`, `composer phpstan` and `composer phpcs` clean.
