### PR TITLE
Leave an empty field untouched in EscapeFormula::escapeField

### DIFF
--- a/src/EscapeFormula.php
+++ b/src/EscapeFormula.php
@@ -110,6 +110,7 @@ class EscapeFormula
 
         return match (true) {
             null === $strOrNull,
+            '' === $strOrNull,
             !isset($this->special_chars[$strOrNull[0]]) && !str_starts_with($strOrNull, $this->escape) => $cell,
             default => $this->escape.$strOrNull,
         };

--- a/src/EscapeFormulaTest.php
+++ b/src/EscapeFormulaTest.php
@@ -173,4 +173,9 @@ final class EscapeFormulaTest extends TestCase
         $formatter = new EscapeFormula('xy');
         self::assertSame(['xy=2+5', 'xy'], $formatter->unescapeRecord(['xyxy=2+5', 'xyxy']));
     }
+
+    public function testEscapeRecordLeavesAnEmptyFieldUntouched(): void
+    {
+        self::assertSame([''], (new EscapeFormula())->escapeRecord(['']));
+    }
 }


### PR DESCRIPTION
`(new EscapeFormula())->escapeRecord([''])` raises `Uninitialized string offset 0`.

`escapeField` reads `$strOrNull[0]` before checking that the string is non-empty.

Leave an empty field untouched, alongside the existing `null` arm.

New test fails on master under `--fail-on-warning` and passes with the change; `composer phpunit` no longer reports the warning, `composer phpstan` and `composer phpcs` clean.
